### PR TITLE
Use compare for soundness check rather than join

### DIFF
--- a/lib/analysis/defuse_bool.ml
+++ b/lib/analysis/defuse_bool.ml
@@ -7,10 +7,17 @@ module IsZeroLattice = struct
   let name = "isZero"
 
   type t = Top | Zero | NonZero | Bot
-  [@@deriving ord, eq, show { with_path = false }]
+  [@@deriving eq, show { with_path = false }]
 
   let bottom = Bot
   let pretty t = Containers_pp.text (show t)
+
+  let compare a b =
+    match (a, b) with
+    | a, b when equal a b -> 0
+    | Bot, _ | _, Top -> -1
+    | _, Bot | Top, _ -> 1
+    | _ -> 1
 
   let join a b =
     match (a, b) with

--- a/test/lang/value_soundness.ml
+++ b/test/lang/value_soundness.ml
@@ -70,7 +70,7 @@ struct
   let is_sound (_, _, abstract, concrete) =
     let abstract = fst @@ Lazy.force abstract in
     let concrete = fst @@ Lazy.force concrete in
-    V.equal abstract (V.join abstract concrete)
+    V.compare concrete abstract <= 0
 
   let suite =
     let open QCheck in


### PR DESCRIPTION
Currently the prop tests for value soundness take the join of the abstract and concrete evaluation, then check for equality. However, this only holds true for analyses where join does not contain a reduction step.

This has been replaced with `V.compare concrete abstract <= 0` which is more accurate and holds for sound reductions.

Also the compare function for `IsZeroLattice` has been rewritten manually as the derived version caused `Top < NonZero`.