### PR TITLE
Add semicolons on multiple require summaries

### DIFF
--- a/lib/lang/procedure.ml
+++ b/lib/lang/procedure.ml
@@ -474,45 +474,43 @@ let iter_blocks_topo_rev p =
 
 let pretty_spec show_var show_expr (p : ('a, 'b) proc_spec) =
   let open Containers_pp in
-  let ml f v = if List.is_empty v then [] else [ f v ] in
+  let ml f v = if List.is_empty v then [] else [ f v ^ text ";" ] in
   nest 2
     (newline
     ^ append_nl
         (ml
            (fun x ->
              text "modifies "
-             ^ nest 2 (fill_map (text "," ^ newline) show_var x)
-             ^ text ";")
+             ^ nest 2 (fill_map (text "," ^ newline) show_var x))
            p.modifies_globs
         @ ml
             (fun x ->
               text "captures "
-              ^ nest 2 (fill_map (text "," ^ newline) show_var x)
-              ^ text ";")
+              ^ nest 2 (fill_map (text "," ^ newline) show_var x))
             p.captures_globs
         @ ml
             (fun x ->
-              append_nl
-                (List.map
-                   (fun v -> text "requires " ^ show_expr v ^ text ";")
-                   x))
+              append_l
+                ~sep:(text ";" ^ newline)
+                (List.map (fun v -> text "requires " ^ show_expr v) x))
             p.requires
         @ ml
             (fun x ->
-              append_nl
-                (List.map (fun v -> text "ensures " ^ show_expr v ^ text ";") x))
+              append_l
+                ~sep:(text ";" ^ newline)
+                (List.map (fun v -> text "ensures " ^ show_expr v) x))
             p.ensures
         @ ml
             (fun x ->
-              append_nl
-                (List.map (fun v -> text "rely " ^ show_expr v ^ text ";") x))
+              append_l
+                ~sep:(text ";" ^ newline)
+                (List.map (fun v -> text "rely " ^ show_expr v) x))
             p.rely
         @ ml
             (fun x ->
-              append_nl
-                (List.map
-                   (fun v -> text "guarantee " ^ show_expr v ^ text ";")
-                   x))
+              append_l
+                ~sep:(text ";" ^ newline)
+                (List.map (fun v -> text "guarantee " ^ show_expr v) x))
             p.guarantee))
 
 let pretty show_lvar show_var show_expr p =


### PR DESCRIPTION
When dumping il on a procedure with multiple requires/ensures/rely/guarantees clauses, a semicolon is only added to the last clause instead of all lines, and this pr fixes that

e.g. it was emitting
```
  requires boolnot(boolnot(eq($_PC:bv64, 0x400d40:bv64)))
  requires eq($_PC:bv64, 0x400d40:bv64);
```