### PR TITLE
log source filtering, and accept `-` as script file

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -7,7 +7,7 @@ open Cmdliner.Term.Syntax
 let () = Printexc.record_backtrace true
 
 let fname =
-  let doc = "Input file name (filename.il)" in
+  let doc = "Input file name (e.g., filename.il or - for stdin)" in
   Arg.(required & pos 0 (some string) None & info [] ~docv:"FNAME" ~doc)
 
 let proc =
@@ -60,25 +60,26 @@ let dump_proc_cmd =
   let info = Cmd.info "dump-il" ~version:"alpha" ~doc in
   Cmd.v info Term.(const dump_proc $ fname $ proc)
 
+(** Runs the [inner] function with an input channel. The input channel is from
+    opening the given [fname], or stdin if [fname] is [-]. *)
+let with_in_or_stdin fname inner =
+  match fname with "-" -> inner stdin | fname -> CCIO.with_in fname inner
+
 let run_script fname =
   let st = Script.init_st in
-  let r =
-    CCIO.with_in fname (fun c ->
-        let iter = CCIO.read_lines_iter c in
-        try
-          let _ = Iter.fold (fun acc l -> Script.of_str acc l) st iter in
-          Ok ()
-        with
-        | Common.ReplError { __LINE__; __FILE__; __FUNCTION__; msg; cmd } ->
-          let n =
-            Printf.sprintf "Error in %s: %s at %s %s:%d" cmd
-              (Containers_pp.Term_color.color `Red (Containers_pp.text msg)
-              |> Containers_pp.Pretty.to_string ~width:80)
-              __FUNCTION__ __FILE__ __LINE__
-          in
-          Error n)
-  in
-  r
+  with_in_or_stdin fname @@ fun chan ->
+  let iter = CCIO.read_lines_iter chan in
+  try
+    let _ = Iter.fold (fun acc l -> Script.of_str acc l) st iter in
+    Ok ()
+  with Common.ReplError { __LINE__; __FILE__; __FUNCTION__; msg; cmd } ->
+    let n =
+      Printf.sprintf "Error in %s: %s at %s %s:%d" cmd
+        (Containers_pp.Term_color.color `Red (Containers_pp.text msg)
+        |> Containers_pp.Pretty.to_string ~width:80)
+        __FUNCTION__ __FILE__ __LINE__
+    in
+    Error n
 
 (*
 let callgraph_cmd =
@@ -101,7 +102,7 @@ let main () =
   Trace_core.set_process_name "main";
   Trace_core.set_thread_name "t1";
   Logs.set_level (Some Logs.Error);
-  Logs.set_reporter (Logger.reporter Format.err_formatter);
+  Logs.set_reporter (reporter Format.err_formatter);
   exit (Cmd.eval_result cmd)
 
 let () = Trace_tef.with_setup ~out:(`File "trace.json") () @@ fun () -> main ()

--- a/bin/script.ml
+++ b/bin/script.ml
@@ -21,8 +21,24 @@ let print_blocks_topo_fwd chan p =
       output_string chan "\n")
     ids_rev
 
-let assert_atoms n args =
-  if List.length args < n then
+let assert_atoms =
+  let error arg =
+    Common.ReplError
+      {
+        msg =
+          Printf.sprintf "expected an atom but got a list: %s"
+            (Sexp.to_string arg);
+        cmd = "unk";
+        __FILE__;
+        __FUNCTION__;
+        __LINE__;
+      }
+  in
+  List.map (function `Atom n -> n | non_atom -> raise (error non_atom))
+
+let assert_n_atoms n args =
+  let atoms = assert_atoms args in
+  if List.length atoms < n then
     raise
       (Common.ReplError
          {
@@ -33,7 +49,7 @@ let assert_atoms n args =
            __FUNCTION__;
            __LINE__;
          });
-  List.map (function `Atom n -> n | _ -> failwith "expected atom") args
+  atoms
 
 type dsl_st = { load_st : Loader.Loadir.load_st option; line : int }
 
@@ -67,30 +83,45 @@ let of_cmd st (e : Containers.Sexp.t) =
       match cmd with
       | "skip" -> st
       | "log-level" ->
-          let level = List.hd (assert_atoms 1 args) in
-          let open Result in
-          let a =
-            match Result.to_opt @@ Logs.level_of_string level with
-            | Some a -> a
-            | None ->
-                raise
-                  (Common.ReplError
-                     {
-                       msg =
+          let make_error msg =
+            Common.ReplError
+              { msg; cmd = "log-level"; __FILE__; __FUNCTION__; __LINE__ }
+          in
+
+          let level, src_names =
+            match assert_atoms args with
+            | [] -> raise (make_error "Expected at least one argument")
+            | level :: rest -> (
+                match Result.to_opt @@ Logs.level_of_string level with
+                | Some a -> (a, rest)
+                | None ->
+                    raise
+                      (make_error
                          "Incorrect log level option given, correct options \
                           are [\"info\", \"quiet\", \"app\", \"error\", \
-                          \"warning\", \"debug\"]";
-                       cmd = "log-level";
-                       __FILE__;
-                       __FUNCTION__;
-                       __LINE__;
-                     })
+                          \"warning\", \"debug\"]"))
           in
-          Logs.set_level a;
+          (match src_names with
+          | [] -> Logs.set_level level
+          | src_names ->
+              let srcs =
+                Iter.of_list (Logs.Src.list ())
+                |> Iter.map (fun src -> (Logs.Src.name src, src))
+                |> Iter.to_hashtbl
+              in
+              let find name =
+                Hashtbl.find_opt srcs name
+                |> CCOption.get_lazy (fun () ->
+                    raise
+                      (make_error @@ Printf.sprintf "source %s not found" name))
+              in
+              List.iter
+                (fun name -> Logs.Src.set_level (find name) level)
+                src_names);
           st
       | "load-il" -> (
           try
-            let args = assert_atoms (List.length args) args in
+            let args = assert_n_atoms (List.length args) args in
             let st =
               List.fold_left
                 (fun acc fname ->
@@ -112,14 +143,14 @@ let of_cmd st (e : Containers.Sexp.t) =
             (get_prog st).procs;
           st
       | "list-blocks-il" ->
-          let proc = List.hd (assert_atoms 1 args) in
+          let proc = List.hd (assert_n_atoms 1 args) in
           let id = (get_prog st).proc_names.get_id proc in
           let p = IDMap.find id (get_prog st).procs in
           print_blocks_topo_fwd stdout p;
           st
       | "write-proc-cfg" ->
           let proc, ofile =
-            assert_atoms 2 args |> function
+            assert_n_atoms 2 args |> function
             | [ proc; ofile ] -> (proc, ofile)
             | _ -> failwith "unreachable"
           in
@@ -152,14 +183,14 @@ let of_cmd st (e : Containers.Sexp.t) =
                 (Procedure.graph p |> Option.get_exn_or "procedure has no graph"));
           st
       | "dump-proc-il" ->
-          let proc = List.hd (assert_atoms 1 args) in
+          let proc = List.hd (assert_n_atoms 1 args) in
           let id = (get_prog st).proc_names.get_id proc in
           let p = IDMap.find id (get_prog st).procs in
           print_proc stdout p;
           st
       | "write-proc-il" ->
           let proc, ofile =
-            assert_atoms 2 args |> function
+            assert_n_atoms 2 args |> function
             | [ proc; ofile ] -> (proc, ofile)
             | _ -> failwith "unreachable"
           in
@@ -169,16 +200,16 @@ let of_cmd st (e : Containers.Sexp.t) =
               print_proc c p);
           st
       | "dump-il" ->
-          let ofile = List.hd @@ assert_atoms 1 args in
+          let ofile = List.hd @@ assert_n_atoms 1 args in
           CCIO.with_out ofile (fun c -> Program.pretty_to_chan c (get_prog st));
           st
       | "dump-boogie" ->
-          let ofile = List.hd @@ assert_atoms 1 args in
+          let ofile = List.hd @@ assert_n_atoms 1 args in
           CCIO.with_out ofile (fun c ->
               Backends.Boogie.pretty_to_chan c (get_prog st));
           st
       | "interp-out" ->
-          let ofile = List.hd @@ assert_atoms 1 args in
+          let ofile = List.hd @@ assert_n_atoms 1 args in
           let prog = get_prog st in
           let main =
             IDMap.find (Option.get_exn_or "no" prog.entry_proc) prog.procs
@@ -201,14 +232,14 @@ let of_cmd st (e : Containers.Sexp.t) =
           CCIO.with_out ofile (fun c -> output_string c ist);
           st
       | "run-transforms" ->
-          let args = assert_atoms (List.length args) args in
+          let args = assert_n_atoms (List.length args) args in
           let ba = Bincaml.Passes.PassManager.batch_of_list args in
           let prog =
             Some (Bincaml.Passes.PassManager.run_batch ba (get_prog st))
           in
           set_prog st prog
       | "run-transform" ->
-          let args = assert_atoms 1 args in
+          let args = assert_n_atoms 1 args in
           let ba = Bincaml.Passes.PassManager.batch_of_list args in
           let prog =
             Some (Bincaml.Passes.PassManager.run_batch ba (get_prog st))

--- a/lib/analysis/irreducible_loops.ml
+++ b/lib/analysis/irreducible_loops.ml
@@ -3,6 +3,10 @@
 open Lang
 open Common
 
+let logs_src = Logs.Src.create "analysis.irreducible_loops"
+
+module Logs = (val Logs.src_log logs_src : Logs.LOG)
+
 module type GSig = sig
   (** Minimal graph structure for computing forest *)
 
@@ -474,6 +478,15 @@ module ProcIntra = struct
       information label for each block in the procedure. Returns all loop tags
       for blocks in reverse-topological order. *)
   let solve_proc p =
-    Procedure.get_entry_block p
-    |> Option.flat_map_l (fun entry -> solve p entry)
+    let block_infos =
+      Procedure.get_entry_block p
+      |> Option.flat_map_l (fun entry -> solve p entry)
+    in
+    Logs.info (fun m ->
+        m "found %d loops, %d irreducible" (List.length block_infos)
+          (List.count
+             (( function `IrreducibleHeader -> true | _ -> false )
+             % classify_block)
+             block_infos));
+    block_infos
 end

--- a/lib/util/logger.ml
+++ b/lib/util/logger.ml
@@ -35,3 +35,18 @@ module Logger = struct
     in
     { Logs.report }
 end
+
+let reporter ppf =
+  let report src level ~over k msgf =
+    let k _ =
+      over ();
+      k ()
+    in
+    let with_stamp h _tags k ppf fmt =
+      Format.kfprintf k ppf
+        ("%a (%s) @[" ^^ fmt ^^ "@]@.")
+        Logs.pp_header (level, h) (Logs.Src.name src)
+    in
+    msgf @@ fun ?header ?tags fmt -> with_stamp header tags k ppf fmt
+  in
+  { Logs.report }

--- a/test/cram/logs.t
+++ b/test/cram/logs.t
@@ -1,0 +1,47 @@
+Logs should print conditionally on whether their source has the right level.
+
+  $ cat << EOF | bincaml script -
+  > (load-il "../../examples/irreducible_loop_1.il")
+  > (log-level "info")
+  > (log-level "info" "analysis.irreducible_loops")
+  > (run-transforms "irreducible-loops")
+  > EOF
+  [INFO] (application) Starting irreducible-loops
+  [INFO] (analysis.irreducible_loops) found 15 loops, 1 irreducible
+  [INFO] (analysis.irreducible_loops) found 0 loops, 0 irreducible
+
+
+  $ cat << EOF | bincaml script -
+  > (load-il "../../examples/irreducible_loop_1.il")
+  > (log-level "info")
+  > (log-level "error" "analysis.irreducible_loops")
+  > (run-transforms "irreducible-loops")
+  > EOF
+  [INFO] (application) Starting irreducible-loops
+
+Some error messages for log configuration.
+
+  $ cat << EOF | bincaml script -
+  > (load-il "../../examples/irreducible_loop_1.il")
+  > (log-level)
+  > (run-transforms "irreducible-loops")
+  > EOF
+  bincaml: Error in log-level: Expected at least one argument at Dune__exe__Script.of_cmd.(fun).make_error bin/script.ml:88
+  [123]
+
+  $ cat << EOF | bincaml script -
+  > (load-il "../../examples/irreducible_loop_1.il")
+  > (log-level "blah")
+  > (run-transforms "irreducible-loops")
+  > EOF
+  bincaml: Error in log-level: Incorrect log level option given, correct options are ["info", "quiet", "app", "error", "warning", "debug"] at Dune__exe__Script.of_cmd.(fun).make_error bin/script.ml:88
+  [123]
+
+
+  $ cat << EOF | bincaml script -
+  > (load-il "../../examples/irreducible_loop_1.il")
+  > (log-level "info" "nowheoijifsda")
+  > (run-transforms "irreducible-loops")
+  > EOF
+  bincaml: Error in log-level: source nowheoijifsda not found at Dune__exe__Script.of_cmd.(fun).make_error bin/script.ml:88
+  [123]

--- a/test/cram/malloc_free.t
+++ b/test/cram/malloc_free.t
@@ -13,10 +13,10 @@
   var $mem_encoding: MemEncoding;
   
   function  f$magic(a: [bv64]bv8, b: [bv64]bv8) returns ([bv64]bv8) { a }
-  function {:extern } {:bvbuiltin "bvadd"} bvadd_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvand"} bvand_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvule"} bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
-  function {:extern } {:bvbuiltin "bvult"} bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvadd"} {:extern } bvadd_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvand"} {:extern } bvand_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvule"} {:extern } bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvult"} {:extern } bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
   function {:extern } load64_le(#memory: [bv64]bv8, #index: bv64) returns (bv64) {
     (((((((#memory[bvadd_bv64(#index, 7bv64)]
            ++
@@ -34,38 +34,38 @@
      ++
      #memory[bvadd_bv64(#index, 0bv64)]): bv64
   }
-  function {:inline } {:extern } me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     addr
   }
-  function {:inline } {:extern } me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
+  function {:extern } {:inline } me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
     mem_encoding->addr_is_heap[addr]
   }
-  function {:inline } {:extern } me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     bvand_bv64(addr, 4294967295bv64)
   }
-  function {:inline } {:extern } me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     bvand_bv64(alloc, 18446744069414584320bv64)
   }
-  function {:inline } {:extern } me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
+  function {:extern } {:inline } me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
     mem_encoding->alloc_live[alloc]
   }
-  function {:inline } {:extern } me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
+  function {:extern } {:inline } me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
     mem_encoding->(alloc_live := mem_encoding->alloc_live[alloc := live])
   }
-  function {:inline } {:extern } me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     mem_encoding->alloc_size[alloc]
   }
-  function {:inline } {:extern } me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
     mem_encoding->(alloc_size := mem_encoding->alloc_size[alloc := size])
   }
-  function {:inline } {:extern } me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
     me_alloc_size_update(
       me_alloc_live_update(mem_encoding, me_addr_alloc(mem_encoding, addr), 1bv2),
       me_addr_alloc(mem_encoding, addr),
       size
     )
   }
-  function {:inline } {:extern } me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     ((((me_addr_is_heap(mem_encoding, addr)&&(me_alloc_base(mem_encoding, addr) == addr))&&(me_alloc_live(
           mem_encoding,
           me_addr_alloc(mem_encoding, addr)
@@ -74,7 +74,7 @@
        size
      ))
   }
-  function {:inline } {:extern } me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
+  function {:extern } {:inline } me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
     (((forall 
        i: bv64 :: 
        {me_addr_is_heap(mem_encoding, i)} 
@@ -86,7 +86,7 @@
       {me_alloc_live(mem_encoding, i)} 
       ((!(me_addr_is_heap(mem_encoding, i))) ==> (me_alloc_live(mem_encoding, i) == 2bv2))))
   }
-  function {:inline } {:extern } me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     (me_addr_is_heap(mem_encoding, addr) ==> ((me_alloc_live(
          mem_encoding,
          me_alloc_base(mem_encoding, me_addr_alloc(mem_encoding, addr))
@@ -99,7 +99,7 @@
       )))
   }
   datatype MemEncoding {MemEncoding(alloc_live: [bv64]bv2, alloc_size: [bv64]bv64, addr_is_heap: [bv64]bool)}
-  function {:extern } {:define } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
+  function {:define } {:extern } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]][bvadd_bv64(#index, 1bv64) := #value[16:8]][bvadd_bv64(
       #index,
       2bv64
@@ -111,27 +111,9 @@
       6bv64
     ) := #value[56:48]][bvadd_bv64(#index, 7bv64) := #value[64:56]]
   }
-  function {:extern } {:define } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
+  function {:define } {:extern } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]]
   }
-  
-  procedure p$free();
-    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
-    ensures ($mem_encoding == me_alloc_live_update(
-       old($mem_encoding),
-       me_addr_alloc(old($mem_encoding), $R0),
-       2bv2
-     ));
-    requires me_addr_is_heap($mem_encoding, $R0);
-    requires (0bv64 == me_addr_offset($mem_encoding, $R0));
-    requires (me_alloc_live($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == 1bv2);
-  
-  procedure p$malloc();
-    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
-    ensures me_can_allocate(old($mem_encoding), $R0, old($R0));
-    ensures (me_addr_offset($mem_encoding, $R0) == 0bv64);
-    ensures (me_alloc_base($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == $R0);
-    ensures ($mem_encoding == me_allocate(old($mem_encoding), $R0, old($R0)));
   
   procedure p$main();
     modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
@@ -208,6 +190,24 @@
       assert true;
       return;
   }
+  
+  procedure p$malloc();
+    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
+    ensures me_can_allocate(old($mem_encoding), $R0, old($R0));
+    ensures (me_addr_offset($mem_encoding, $R0) == 0bv64);
+    ensures (me_alloc_base($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == $R0);
+    ensures ($mem_encoding == me_allocate(old($mem_encoding), $R0, old($R0)));
+  
+  procedure p$free();
+    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
+    ensures ($mem_encoding == me_alloc_live_update(
+       old($mem_encoding),
+       me_addr_alloc(old($mem_encoding), $R0),
+       2bv2
+     ));
+    requires me_addr_is_heap($mem_encoding, $R0);
+    requires (0bv64 == me_addr_offset($mem_encoding, $R0));
+    requires (me_alloc_live($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == 1bv2);
 
   $ boogie ./good.bpl
   
@@ -226,10 +226,10 @@
   var $mem_encoding: MemEncoding;
   
   function  f$magic(a: [bv64]bv8, b: [bv64]bv8) returns ([bv64]bv8) { a }
-  function {:extern } {:bvbuiltin "bvadd"} bvadd_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvand"} bvand_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvule"} bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
-  function {:extern } {:bvbuiltin "bvult"} bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvadd"} {:extern } bvadd_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvand"} {:extern } bvand_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvule"} {:extern } bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvult"} {:extern } bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
   function {:extern } load64_le(#memory: [bv64]bv8, #index: bv64) returns (bv64) {
     (((((((#memory[bvadd_bv64(#index, 7bv64)]
            ++
@@ -247,38 +247,38 @@
      ++
      #memory[bvadd_bv64(#index, 0bv64)]): bv64
   }
-  function {:inline } {:extern } me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     addr
   }
-  function {:inline } {:extern } me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
+  function {:extern } {:inline } me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
     mem_encoding->addr_is_heap[addr]
   }
-  function {:inline } {:extern } me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     bvand_bv64(addr, 4294967295bv64)
   }
-  function {:inline } {:extern } me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     bvand_bv64(alloc, 18446744069414584320bv64)
   }
-  function {:inline } {:extern } me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
+  function {:extern } {:inline } me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
     mem_encoding->alloc_live[alloc]
   }
-  function {:inline } {:extern } me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
+  function {:extern } {:inline } me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
     mem_encoding->(alloc_live := mem_encoding->alloc_live[alloc := live])
   }
-  function {:inline } {:extern } me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     mem_encoding->alloc_size[alloc]
   }
-  function {:inline } {:extern } me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
     mem_encoding->(alloc_size := mem_encoding->alloc_size[alloc := size])
   }
-  function {:inline } {:extern } me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
     me_alloc_size_update(
       me_alloc_live_update(mem_encoding, me_addr_alloc(mem_encoding, addr), 1bv2),
       me_addr_alloc(mem_encoding, addr),
       size
     )
   }
-  function {:inline } {:extern } me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     ((((me_addr_is_heap(mem_encoding, addr)&&(me_alloc_base(mem_encoding, addr) == addr))&&(me_alloc_live(
           mem_encoding,
           me_addr_alloc(mem_encoding, addr)
@@ -287,7 +287,7 @@
        size
      ))
   }
-  function {:inline } {:extern } me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
+  function {:extern } {:inline } me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
     (((forall 
        i: bv64 :: 
        {me_addr_is_heap(mem_encoding, i)} 
@@ -299,7 +299,7 @@
       {me_alloc_live(mem_encoding, i)} 
       ((!(me_addr_is_heap(mem_encoding, i))) ==> (me_alloc_live(mem_encoding, i) == 2bv2))))
   }
-  function {:inline } {:extern } me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     (me_addr_is_heap(mem_encoding, addr) ==> ((me_alloc_live(
          mem_encoding,
          me_alloc_base(mem_encoding, me_addr_alloc(mem_encoding, addr))
@@ -312,7 +312,7 @@
       )))
   }
   datatype MemEncoding {MemEncoding(alloc_live: [bv64]bv2, alloc_size: [bv64]bv64, addr_is_heap: [bv64]bool)}
-  function {:extern } {:define } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
+  function {:define } {:extern } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]][bvadd_bv64(#index, 1bv64) := #value[16:8]][bvadd_bv64(
       #index,
       2bv64
@@ -324,27 +324,9 @@
       6bv64
     ) := #value[56:48]][bvadd_bv64(#index, 7bv64) := #value[64:56]]
   }
-  function {:extern } {:define } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
+  function {:define } {:extern } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]]
   }
-  
-  procedure p$free();
-    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
-    ensures ($mem_encoding == me_alloc_live_update(
-       old($mem_encoding),
-       me_addr_alloc(old($mem_encoding), $R0),
-       2bv2
-     ));
-    requires me_addr_is_heap($mem_encoding, $R0);
-    requires (0bv64 == me_addr_offset($mem_encoding, $R0));
-    requires (me_alloc_live($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == 1bv2);
-  
-  procedure p$malloc();
-    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
-    ensures me_can_allocate(old($mem_encoding), $R0, old($R0));
-    ensures (me_addr_offset($mem_encoding, $R0) == 0bv64);
-    ensures (me_alloc_base($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == $R0);
-    ensures ($mem_encoding == me_allocate(old($mem_encoding), $R0, old($R0)));
   
   procedure p$main();
     modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
@@ -421,10 +403,28 @@
       assert true;
       return;
   }
+  
+  procedure p$malloc();
+    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
+    ensures me_can_allocate(old($mem_encoding), $R0, old($R0));
+    ensures (me_addr_offset($mem_encoding, $R0) == 0bv64);
+    ensures (me_alloc_base($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == $R0);
+    ensures ($mem_encoding == me_allocate(old($mem_encoding), $R0, old($R0)));
+  
+  procedure p$free();
+    modifies $mem_encoding, $mem, $stack, $R0, $R1, $R16, $R17, $R29, $R30, $R31;
+    ensures ($mem_encoding == me_alloc_live_update(
+       old($mem_encoding),
+       me_addr_alloc(old($mem_encoding), $R0),
+       2bv2
+     ));
+    requires me_addr_is_heap($mem_encoding, $R0);
+    requires (0bv64 == me_addr_offset($mem_encoding, $R0));
+    requires (me_alloc_live($mem_encoding, me_addr_alloc($mem_encoding, $R0)) == 1bv2);
 
   $ boogie ./bad.bpl
-  ./bad.bpl(176,5): Error: this assertion could not be proved
+  ./bad.bpl(158,5): Error: this assertion could not be proved
   Execution trace:
-      ./bad.bpl(146,3): b#main_entry
+      ./bad.bpl(128,3): b#main_entry
   
   Boogie program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
log format looks like this now, without timestamps
```
[INFO] (application) Starting irreducible-loops
[INFO] (analysis.irreducible_loops) found 15 loops, 1 irreducible
[INFO] (analysis.irreducible_loops) found 0 loops, 0 irreducible
```

timestamps would cause trouble with cram tests.

the log-level sexp command is changed to accept one or more source names after the log level. 
```
(log-level "info")
(log-level "error" "analysis.irreducible_loops")
```

Closes https://github.com/agle/bincaml/issues/65

i don't know why some other cram tests have changed...