### PR TITLE
require `cmdliner>=2`

### DIFF
--- a/bincaml.opam
+++ b/bincaml.opam
@@ -23,7 +23,7 @@ depends: [
   "containers-data"
   "ppx_deriving"
   "ocamlgraph"
-  "cmdliner"
+  "cmdliner" {>= "2.0.0"}
   "pp_loc"
   "fmt"
   "patricia-tree"

--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   containers-data
   ppx_deriving
   ocamlgraph
-  cmdliner
+  (cmdliner (>= "2.0.0"))
   pp_loc
   fmt
   patricia-tree


### PR DESCRIPTION
versions less than 2 don't have the `Cmd.make` function which we now use.