### PR TITLE
Collapse empty blocks

### DIFF
--- a/examples/collapse_edge.il
+++ b/examples/collapse_edge.il
@@ -2,29 +2,14 @@ prog entry @main;
 
 proc @main(a:bv64) -> (c:bv64)
 [
-    block %inputs [
-        goto(%a);
-    ];
-    block %a [
-        goto(%b, %c);
-    ];
-    block %b [
-        goto(%c);
-    ];
-    block %c [
-        var b:bv64 := a:bv64;
-        goto(%d);
-    ];
-    block %d [
-        goto(%e);
-    ];
-    block %e (
-        var c_1:bv64 := phi(%d -> b:bv64),
-    ) [
+    block %inputs [ goto(%a); ];
+    block %a [ goto(%b, %c); ];
+    block %b [ goto(%c); ];
+    block %c [ var b:bv64 := a:bv64; goto(%d); ];
+    block %d [ goto(%e); ];
+    block %e ( var c_1:bv64 := phi(%d -> b:bv64)) [
         var c:bv64 := c_1:bv64;
         goto(%f);
     ];
-    block %f [
-        return;
-    ];
+    block %f [ return; ];
 ];

--- a/examples/collapse_edge.il
+++ b/examples/collapse_edge.il
@@ -1,0 +1,30 @@
+prog entry @main;
+
+proc @main(a:bv64) -> (c:bv64)
+[
+    block %inputs [
+        goto(%a);
+    ];
+    block %a [
+        goto(%b, %c);
+    ];
+    block %b [
+        goto(%c);
+    ];
+    block %c [
+        var b:bv64 := a:bv64;
+        goto(%d);
+    ];
+    block %d [
+        goto(%e);
+    ];
+    block %e (
+        var c_1:bv64 := phi(%d -> b:bv64),
+    ) [
+        var c:bv64 := c_1:bv64;
+        goto(%f);
+    ];
+    block %f [
+        return;
+    ];
+];

--- a/lib/backends/boogie.ml
+++ b/lib/backends/boogie.ml
@@ -204,7 +204,7 @@ let rec pretty_attribute (attr : Program.e Attrib.t) =
 and pretty_attribute_map (key : string) (a : Program.e Attrib.attrib_map) =
   let open Containers_pp in
   StringMap.find_opt key a |> Option.to_list
-  |> List.flat_map (function `Assoc m -> StringMap.to_list m | _ -> [])
+  |> List.flat_map (function `Assoc m -> StringMap.bindings m | _ -> [])
   |> List.map (function k, f ->
       bracket "{"
         (text ":" ^ text (String.drop 1 k) ^+ append_sp @@ pretty_attribute f)

--- a/lib/lang/procedure.ml
+++ b/lib/lang/procedure.ml
@@ -338,6 +338,20 @@ let get_entry_block p =
         Some (List.hd id))
   with Not_found -> None
 
+let is_entry_block p id =
+  graph p
+  |> Option.map (fun g ->
+      G.pred g (Vert.Begin id) |> List.mem ~eq:Vert.equal Vert.Entry)
+  |> Option.get_or ~default:false
+
+let set_entry_block p id =
+  let open Edge in
+  let open G in
+  p
+  |> map_graph (fun g ->
+      let g = fold_succ (fun v g -> remove_edge g Entry v) g Entry g in
+      add_edge g Entry (Begin id))
+
 (** Get the block for an id
 
     raise Not_found when the block does not exist. *)

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -159,11 +159,25 @@ module PassManager = struct
          definitions from parameters";
     }
 
-  let cleanup_cfg =
+  let remove_unreachable_blocks =
     {
       name = "remove-unreachable-block";
       apply = Proc Transforms.Cleanup_cfg.remove_blocks_unreachable_from_entry;
       doc = "Remove blocks unreachable from entry";
+    }
+
+  let collapse_empty_blocks =
+    {
+      name = "collapse-empty-blocks";
+      apply = Proc Transforms.Cleanup_cfg.collapse_empty_blocks;
+      doc = "Collapses empty intermediate blocks";
+    }
+
+  let cleanup_cfg =
+    {
+      name = "cleanup-cfg";
+      apply = Proc Transforms.Cleanup_cfg.cleanup_cfg;
+      doc = "Collapses empty intermediate blocks";
     }
 
   let irreducible_loop =
@@ -176,7 +190,7 @@ module PassManager = struct
   let full_ssa =
     {
       name = "ssa";
-      apply = Batch [ cleanup_cfg; sparams; sssa; remove_unused ];
+      apply = Batch [ remove_unreachable_blocks; sparams; sssa; remove_unused ];
       doc =
         "Complete SSA pipeline for early IR (global register parameterless \
          form)";
@@ -282,7 +296,13 @@ module PassManager = struct
       apply =
         Batch
           [
-            cf_exprs; linear_const; cf_exprs; linear_copy; cf_exprs; inter_dead;
+            cf_exprs;
+            linear_const;
+            cf_exprs;
+            linear_copy;
+            cf_exprs;
+            inter_dead;
+            cleanup_cfg;
           ];
       doc =
         "Performs some simplifications (linear constant propagation, linear \
@@ -293,7 +313,7 @@ module PassManager = struct
   let passes =
     [
       irreducible_loop;
-      cleanup_cfg;
+      remove_unreachable_blocks;
       dfg_bool;
       dfg_ival_wint_product;
       demo_ival_wint_cfg;

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -314,6 +314,8 @@ module PassManager = struct
     [
       irreducible_loop;
       remove_unreachable_blocks;
+      collapse_empty_blocks;
+      cleanup_cfg;
       dfg_bool;
       dfg_ival_wint_product;
       demo_ival_wint_cfg;

--- a/lib/transforms/cleanup_cfg.ml
+++ b/lib/transforms/cleanup_cfg.ml
@@ -1,4 +1,4 @@
-(** Remove unreachable CFG basic-blocks *)
+(** Remove empty and unreachable CFG basic-blocks *)
 
 open Lang
 open Lang.Common
@@ -17,3 +17,40 @@ let remove_blocks_unreachable_from_entry proc =
       | _ -> None)
   in
   unreachable |> List.fold_left Procedure.remove_block proc
+
+let collapse_empty_blocks proc =
+  (* Iteratates over all blocks, and if one is empty we remove all jumps into
+     this block and add jumps from those vertices to the gotos of this block,
+     minus the block itself (in case of a loop on the block itself) *)
+  let is_empty (block : Program.bloc) =
+    Vector.is_empty block.stmts && List.is_empty block.phis
+  in
+  Procedure.fold_blocks_topo_fwd
+    (fun proc bid block ->
+      if is_empty block then
+        let succ =
+          Procedure.blocks_succ proc bid |> Iter.map fst |> List.of_iter
+        in
+        if Procedure.is_entry_block proc bid then
+          (* If this is an entry then set the successor to entry if it's unique *)
+          if List.length succ = 1 then
+            Procedure.set_entry_block proc (List.hd succ)
+          else proc
+        else if List.is_empty succ then
+          (* Don't collapse terminal edges for now *)
+          proc
+        else
+          let proc =
+            Procedure.blocks_pred proc bid
+            |> Iter.fold
+                 (fun proc (pbid, pblock) ->
+                   Procedure.add_goto proc ~from:pbid ~targets:succ)
+                 proc
+          in
+          let proc = Procedure.remove_block proc bid in
+          proc
+      else proc)
+    proc proc
+
+let cleanup_cfg proc =
+  collapse_empty_blocks proc |> remove_blocks_unreachable_from_entry

--- a/lib/transforms/cleanup_cfg.ml
+++ b/lib/transforms/cleanup_cfg.ml
@@ -77,25 +77,26 @@ let collapse_empty_blocks proc =
         else proc)
       proc proc
   in
-  (* We then push the entry block forward to the first non-empty block (this is
-     a second pass to avoid iteration order issues) *)
+  (* We then push the entry block forward to its successor if the entry is empty *)
   let proc =
-    Procedure.fold_blocks_topo_fwd
-      (fun proc bid block ->
-        if is_empty block && Procedure.is_entry_block proc bid then
-          match
-            Procedure.blocks_succ proc bid |> Iter.map fst |> List.of_iter
-          with
-          | [ hd ] ->
-              Procedure.get_block proc hd
-              |> Option.map (fun (hb : Program.bloc) ->
-                  if List.is_empty hb.phis then
-                    Procedure.set_entry_block proc hd
-                  else proc)
-              |> Option.get_or ~default:proc
-          | _ -> proc
-        else proc)
-      proc proc
+    Procedure.get_entry_block proc
+    |> Option.fold
+         (fun proc bid ->
+           let entry = Procedure.find_block proc bid in
+           if is_empty entry then
+             match
+               Procedure.blocks_succ proc bid |> Iter.map fst |> List.of_iter
+             with
+             | [ hd ] ->
+                 Procedure.get_block proc hd
+                 |> Option.map (fun (hb : Program.bloc) ->
+                     if List.is_empty hb.phis then
+                       Procedure.set_entry_block proc hd
+                     else proc)
+                 |> Option.get_or ~default:proc
+             | _ -> proc
+           else proc)
+         proc
   in
   proc
 

--- a/lib/transforms/cleanup_cfg.ml
+++ b/lib/transforms/cleanup_cfg.ml
@@ -25,32 +25,79 @@ let collapse_empty_blocks proc =
   let is_empty (block : Program.bloc) =
     Vector.is_empty block.stmts && List.is_empty block.phis
   in
-  Procedure.fold_blocks_topo_fwd
-    (fun proc bid block ->
-      if is_empty block then
-        let succ =
-          Procedure.blocks_succ proc bid |> Iter.map fst |> List.of_iter
-        in
-        if Procedure.is_entry_block proc bid then
-          (* If this is an entry then set the successor to entry if it's unique *)
-          if List.length succ = 1 then
-            Procedure.set_entry_block proc (List.hd succ)
-          else proc
-        else if List.is_empty succ then
-          (* Don't collapse terminal edges for now *)
-          proc
-        else
-          let proc =
-            Procedure.blocks_pred proc bid
-            |> Iter.fold
-                 (fun proc (pbid, pblock) ->
-                   Procedure.add_goto proc ~from:pbid ~targets:succ)
-                 proc
+  let proc =
+    Procedure.fold_blocks_topo_fwd
+      (fun proc bid block ->
+        if is_empty block then
+          let succ =
+            Procedure.blocks_succ proc bid |> Iter.map fst |> List.of_iter
           in
-          let proc = Procedure.remove_block proc bid in
-          proc
-      else proc)
-    proc proc
+          if Procedure.is_entry_block proc bid then
+            (* We do empty blocks after collapsing intermediate edges *)
+            proc
+          else if List.is_empty succ then
+            (* Don't collapse terminal edges for now *)
+            proc
+          else
+            let proc =
+              Procedure.blocks_pred proc bid
+              |> Iter.fold
+                   (fun proc (pbid, pblock) ->
+                     Procedure.add_goto proc ~from:pbid ~targets:succ)
+                   proc
+            in
+            (* Update phis *)
+            let pred =
+              Procedure.blocks_pred proc bid |> Iter.map fst |> List.of_iter
+            in
+            let proc =
+              Procedure.map_blocks_nondet
+                (fun (sbid, sblock) ->
+                  if List.mem sbid succ then
+                    Block.map
+                      ~phi:
+                        (List.map (fun (phi : Var.t Block.phi) ->
+                             let _, r =
+                               List.find (fst %> ID.equal bid) phi.rhs
+                             in
+                             {
+                               phi with
+                               rhs =
+                                 List.map (fun id -> (id, r)) pred
+                                 @ List.filter
+                                     (fst %> ID.equal bid %> not)
+                                     phi.rhs;
+                             }))
+                      id sblock
+                  else sblock)
+                proc
+            in
+            let proc = Procedure.remove_block proc bid in
+            proc
+        else proc)
+      proc proc
+  in
+  (* We then push the entry block forward to the first non-empty block (this is
+     a second pass to avoid iteration order issues) *)
+  let proc =
+    Procedure.fold_blocks_topo_fwd
+      (fun proc bid block ->
+        if is_empty block && Procedure.is_entry_block proc bid then
+          match
+            Procedure.blocks_succ proc bid |> Iter.map fst |> List.of_iter
+          with
+          | [ hd ] ->
+              Procedure.get_block proc hd
+              |> Option.map (fun (hb : Program.bloc) ->
+                  if List.is_empty hb.phis then
+                    Procedure.set_entry_block proc hd
+                  else proc)
+              |> Option.get_or ~default:proc
+          | _ -> proc
+        else proc)
+      proc proc
+  in
+  proc
 
 let cleanup_cfg proc =
   collapse_empty_blocks proc |> remove_blocks_unreachable_from_entry

--- a/test/cram/collapse_edge.sexp
+++ b/test/cram/collapse_edge.sexp
@@ -1,0 +1,4 @@
+(load-il "../../examples/collapse_edge.il")
+(dump-il "before.il")
+(run-transforms "collapse-empty-blocks")
+(dump-il "after.il")

--- a/test/cram/collapse_edge.t
+++ b/test/cram/collapse_edge.t
@@ -1,0 +1,18 @@
+  $ bincaml script collapse_edge.sexp
+  (load-il ../../examples/collapse_edge.il)
+  (dump-il before.il)
+  (run-transforms collapse-empty-blocks)
+  (dump-il after.il)
+
+  $ diff before.il after.il
+  5,10c5,6
+  <    block %inputs [ goto (%a); ];
+  <    block %a [ goto (%c,%b); ];
+  <    block %b [ goto (%c); ];
+  <    block %c [ var b:bv64 := a:bv64; goto (%d); ];
+  <    block %d [ goto (%e); ];
+  <    block %e ( var c_1:bv64 := phi(%d -> b:bv64) ) [
+  ---
+  >    block %c [ var b:bv64 := a:bv64; goto (%e); ];
+  >    block %e ( var c_1:bv64 := phi(%c -> b:bv64) ) [
+  [1]

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -36,6 +36,8 @@
   inter_dead.sexp
   ../../examples/const.il
   const.sexp
+  ../../examples/collapse_edge.il
+  collapse_edge.sexp
   ll_simple.il
   ll_simple.sexp
   ll_real.sexp

--- a/test/cram/malloc_free.t
+++ b/test/cram/malloc_free.t
@@ -13,25 +13,25 @@
   var $stack: [bv64]bv8;
   datatype MemEncoding {MemEncoding(alloc_live: [bv64]bv2, alloc_size: [bv64]bv64, addr_is_heap: [bv64]bool)}
   var $mem_encoding: MemEncoding;
-  function {:inline } {:extern } $me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     bvand_bv64(addr, 4294967295bv64)
   }
-  function {:inline } {:extern } $me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     bvand_bv64(alloc, 18446744069414584320bv64)
   }
-  function {:inline } {:extern } $me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
+  function {:extern } {:inline } $me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
     mem_encoding->alloc_live[alloc]
   }
-  function {:inline } {:extern } $me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     mem_encoding->alloc_size[alloc]
   }
-  function {:inline } {:extern } $me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     addr
   }
-  function {:inline } {:extern } $me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
+  function {:extern } {:inline } $me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
     mem_encoding->addr_is_heap[addr]
   }
-  function {:inline } {:extern } $me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } $me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     (((($me_addr_is_heap(mem_encoding, addr)
         &&
         ($me_alloc_base(mem_encoding, addr) == addr))
@@ -42,13 +42,13 @@
      &&
      bvult_bv64_bv64_bool(0bv64, size))
   }
-  function {:inline } {:extern } $me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } $me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
     mem_encoding->(alloc_size := mem_encoding->alloc_size[alloc := size])
   }
-  function {:inline } {:extern } $me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
+  function {:extern } {:inline } $me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
     mem_encoding->(alloc_live := mem_encoding->alloc_live[alloc := live])
   }
-  function {:inline } {:extern } $me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } $me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
     $me_alloc_size_update(
       $me_alloc_live_update(
         mem_encoding,
@@ -59,7 +59,7 @@
       size
     )
   }
-  function {:inline } {:extern } $me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
+  function {:extern } {:inline } $me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
     (((forall 
        i: bv64 :: 
        {$me_addr_is_heap(mem_encoding, i)} 
@@ -78,7 +78,7 @@
       {$me_alloc_live(mem_encoding, i)} 
       ((!($me_addr_is_heap(mem_encoding, i))) ==> ($me_alloc_live(mem_encoding, i) == 2bv2))))
   }
-  function {:inline } {:extern } $me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } $me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     ($me_addr_is_heap(mem_encoding, addr) ==> (($me_alloc_live(
          mem_encoding,
          $me_alloc_base(mem_encoding, $me_addr_alloc(mem_encoding, addr))
@@ -109,10 +109,10 @@
      ++
      #memory[bvadd_bv64(#index, 0bv64)]): bv64
   }
-  function {:extern } {:define } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
+  function {:define } {:extern } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]]
   }
-  function {:extern } {:define } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
+  function {:define } {:extern } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]][bvadd_bv64(#index, 1bv64) := #value[16:8]][bvadd_bv64(
       #index,
       2bv64
@@ -124,10 +124,10 @@
       6bv64
     ) := #value[56:48]][bvadd_bv64(#index, 7bv64) := #value[64:56]]
   }
-  function {:extern } {:bvbuiltin "bvadd"} bvadd_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvand"} bvand_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvule"} bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
-  function {:extern } {:bvbuiltin "bvult"} bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvadd"} {:extern } bvadd_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvand"} {:extern } bvand_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvule"} {:extern } bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvult"} {:extern } bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
   
   procedure p$main_2276(R0_in: bv64, R16_in: bv64, R17_in: bv64, R1_in: bv64,
      R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,
@@ -222,25 +222,25 @@
   var $stack: [bv64]bv8;
   datatype MemEncoding {MemEncoding(alloc_live: [bv64]bv2, alloc_size: [bv64]bv64, addr_is_heap: [bv64]bool)}
   var $mem_encoding: MemEncoding;
-  function {:inline } {:extern } $me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_addr_offset(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     bvand_bv64(addr, 4294967295bv64)
   }
-  function {:inline } {:extern } $me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_alloc_base(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     bvand_bv64(alloc, 18446744069414584320bv64)
   }
-  function {:inline } {:extern } $me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
+  function {:extern } {:inline } $me_alloc_live(mem_encoding: MemEncoding, alloc: bv64) returns (bv2) {
     mem_encoding->alloc_live[alloc]
   }
-  function {:inline } {:extern } $me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_alloc_size(mem_encoding: MemEncoding, alloc: bv64) returns (bv64) {
     mem_encoding->alloc_size[alloc]
   }
-  function {:inline } {:extern } $me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
+  function {:extern } {:inline } $me_addr_alloc(mem_encoding: MemEncoding, addr: bv64) returns (bv64) {
     addr
   }
-  function {:inline } {:extern } $me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
+  function {:extern } {:inline } $me_addr_is_heap(mem_encoding: MemEncoding, addr: bv64) returns (bool) {
     mem_encoding->addr_is_heap[addr]
   }
-  function {:inline } {:extern } $me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } $me_can_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     (((($me_addr_is_heap(mem_encoding, addr)
         &&
         ($me_alloc_base(mem_encoding, addr) == addr))
@@ -251,13 +251,13 @@
      &&
      bvult_bv64_bv64_bool(0bv64, size))
   }
-  function {:inline } {:extern } $me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } $me_alloc_size_update(mem_encoding: MemEncoding, alloc: bv64, size: bv64) returns (MemEncoding) {
     mem_encoding->(alloc_size := mem_encoding->alloc_size[alloc := size])
   }
-  function {:inline } {:extern } $me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
+  function {:extern } {:inline } $me_alloc_live_update(mem_encoding: MemEncoding, alloc: bv64, live: bv2) returns (MemEncoding) {
     mem_encoding->(alloc_live := mem_encoding->alloc_live[alloc := live])
   }
-  function {:inline } {:extern } $me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
+  function {:extern } {:inline } $me_allocate(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (MemEncoding) {
     $me_alloc_size_update(
       $me_alloc_live_update(
         mem_encoding,
@@ -268,7 +268,7 @@
       size
     )
   }
-  function {:inline } {:extern } $me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
+  function {:extern } {:inline } $me_init_encoding(mem_encoding: MemEncoding) returns (bool) {
     (((forall 
        i: bv64 :: 
        {$me_addr_is_heap(mem_encoding, i)} 
@@ -287,7 +287,7 @@
       {$me_alloc_live(mem_encoding, i)} 
       ((!($me_addr_is_heap(mem_encoding, i))) ==> ($me_alloc_live(mem_encoding, i) == 2bv2))))
   }
-  function {:inline } {:extern } $me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
+  function {:extern } {:inline } $me_valid_access(mem_encoding: MemEncoding, addr: bv64, size: bv64) returns (bool) {
     ($me_addr_is_heap(mem_encoding, addr) ==> (($me_alloc_live(
          mem_encoding,
          $me_alloc_base(mem_encoding, $me_addr_alloc(mem_encoding, addr))
@@ -318,10 +318,10 @@
      ++
      #memory[bvadd_bv64(#index, 0bv64)]): bv64
   }
-  function {:extern } {:define } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
+  function {:define } {:extern } store8_le(#memory: [bv64]bv8, #index: bv64, #value: bv8) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]]
   }
-  function {:extern } {:define } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
+  function {:define } {:extern } store64_le(#memory: [bv64]bv8, #index: bv64, #value: bv64) returns ([bv64]bv8) {
     #memory[#index := #value[8:0]][bvadd_bv64(#index, 1bv64) := #value[16:8]][bvadd_bv64(
       #index,
       2bv64
@@ -333,10 +333,10 @@
       6bv64
     ) := #value[56:48]][bvadd_bv64(#index, 7bv64) := #value[64:56]]
   }
-  function {:extern } {:bvbuiltin "bvadd"} bvadd_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvand"} bvand_bv64(bv64, bv64) returns (bv64);
-  function {:extern } {:bvbuiltin "bvule"} bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
-  function {:extern } {:bvbuiltin "bvult"} bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvadd"} {:extern } bvadd_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvand"} {:extern } bvand_bv64(bv64, bv64) returns (bv64);
+  function {:bvbuiltin "bvule"} {:extern } bvule_bv64_bv64_bool(bv64, bv64) returns (bool);
+  function {:bvbuiltin "bvult"} {:extern } bvult_bv64_bv64_bool(bv64, bv64) returns (bool);
   
   procedure p$main_2276(R0_in: bv64, R16_in: bv64, R17_in: bv64, R1_in: bv64,
      R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,


### PR DESCRIPTION
```
proc @main(a:bv64) -> (c:bv64)
[
    block %inputs [ goto(%a); ];
    block %a [ goto(%b, %c); ];
    block %b [ goto(%c); ];
    block %c [ var b:bv64 := a:bv64; goto(%d); ];
    block %d [ goto(%e); ];
    block %e ( var c_1:bv64 := phi(%d -> b:bv64) ) [
        var c:bv64 := c_1:
        goto(%f);
    ];
    block %f [ return; ];
];
prog entry @main;
```
becomes
```
proc @main(a:bv64)  -> (c:bv64) {  }
[
   block %c [ var b:bv64 := a:bv64; goto (%e); ];
   block %e ( var c_1:bv64 := phi(%c -> b:bv64) ) [
     var c:bv64 := c_1:bv64;
     goto (%f);
   ];
   block %f [ return; ]
];
prog entry @main;
```