### PR TITLE
tests: add `tree-sitter highlight` to catch invalid node type

### DIFF
--- a/tree-sitter/dune
+++ b/tree-sitter/dune
@@ -1,11 +1,21 @@
 ; checks tree-sitter is valid and unambiguous
 
 (rule
- (deps grammar.js grammar.bnfc.js)
+ (deps grammar.js grammar.bnfc.js tree-sitter.json)
  (alias runtest)
  (enabled_if %{bin-available:tree-sitter})
  (action
   (run tree-sitter generate grammar.js)))
+
+(rule
+ (deps grammar.js grammar.bnfc.js tree-sitter.json queries/highlights.scm)
+ (alias runtest)
+ (enabled_if %{bin-available:tree-sitter})
+ (action
+  (with-stdin-from
+   %{project_root}/examples/cat.il
+   (ignore-stdout
+    (run tree-sitter highlight)))))
 
 ; check that grammar.js is up to date.
 ; requires `bnfc-treesitter` from pac-nix.


### PR DESCRIPTION
if tree-sitter is available, it will raise an error if the highlights file has outdated node references
```
Error in query file ./queries/highlights.scm

Caused by:
    Query error at 93:2. Invalid node type blah
```
tree-sitter tests still don't run in CI, but it means that if someone is working on the tree-sitter, they'll probably be able to see this error.

In future, this should prevent https://github.com/agle/bincaml/pull/134