### PR TITLE
fix: tree-sitter highlight test should depend on tree-sitter generate

### DIFF
--- a/tree-sitter/.gitignore
+++ b/tree-sitter/.gitignore
@@ -48,6 +48,7 @@ zig-out/
 *.tgz
 *.zip
 
-src
+src/*
+!src/dune
 bindings
 tree-sitter-basil-ir

--- a/tree-sitter/dune
+++ b/tree-sitter/dune
@@ -1,14 +1,6 @@
-; checks tree-sitter is valid and unambiguous
-
+; checks tree-sitter highlights are valid
 (rule
- (deps grammar.js grammar.bnfc.js tree-sitter.json)
- (alias runtest)
- (enabled_if %{bin-available:tree-sitter})
- (action
-  (run tree-sitter generate grammar.js)))
-
-(rule
- (deps grammar.js grammar.bnfc.js tree-sitter.json queries/highlights.scm)
+ (deps src/parser.c queries/highlights.scm)
  (alias runtest)
  (enabled_if %{bin-available:tree-sitter})
  (action

--- a/tree-sitter/dune
+++ b/tree-sitter/dune
@@ -1,4 +1,5 @@
 ; checks tree-sitter highlights are valid
+
 (rule
  (deps src/parser.c queries/highlights.scm)
  (alias runtest)

--- a/tree-sitter/src/dune
+++ b/tree-sitter/src/dune
@@ -1,0 +1,10 @@
+(rule
+ (deps ../grammar.js ../grammar.bnfc.js ../tree-sitter.json)
+ (targets grammar.json parser.c node-types.json)
+ (alias runtest)
+ (mode promote)
+ (enabled_if %{bin-available:tree-sitter})
+ (action
+  (chdir
+   ..
+   (run tree-sitter generate grammar.js))))


### PR DESCRIPTION
follow-up to https://github.com/agle/bincaml/pull/137