### PR TITLE
Boogie Backend Phi Nodes

### DIFF
--- a/lib/transforms/boogie_prepass.ml
+++ b/lib/transforms/boogie_prepass.ml
@@ -473,6 +473,39 @@ module Normalise = struct
     in
     prog
 
+  let insert_phi_assigns (prog : Program.t) =
+    (* Boogie doesn't have explicit phi nodes. *)
+    (* We turn each IR phi node into an assign at the end of each source block. *)
+
+    (* Build a map of source block id -> phi node *)
+    Program.map_procedures
+      (fun _ proc ->
+        (* Maps block ids to outgoing assigns *)
+        let assigns : Program.stmt list IDMap.t =
+          Procedure.fold_blocks_topo_fwd
+            (fun acc id block ->
+              (* Fold over the phis... *)
+              block.phis
+              |> List.fold_left
+                   (fun acc (phi : Var.t Block.phi) ->
+                     (* Fold over all source blocks... *)
+                     List.fold_left
+                       (fun acc (id, rhs) ->
+                         (* Add an assign stmt to the source block from rhs to lhs *)
+                         IDMap.add_to_list id
+                           (Stmt.Instr_Assign [ (phi.lhs, BasilExpr.rvar rhs) ])
+                           acc)
+                       acc phi.rhs)
+                   acc)
+            IDMap.empty proc
+        in
+        (* Append the outgoing assigns to each block *)
+        Procedure.map_blocks_nondet
+          (fun (id, b) ->
+            Block.append_stmts b (IDMap.get_or ~default:[] id assigns))
+          proc)
+      prog
+
   let replace_stmts (p : Program.t) =
     Program.map_procedures
       (fun _ p ->
@@ -484,5 +517,5 @@ end
 
 let transform (p : Program.t) =
   p |> Normalise.replace_functions |> Normalise.replace_exprs
-  |> Instructions.transform_add_store_load_decls |> Normalise.replace_stmts
-  |> Builtins.transform_add_builtin_decls
+  |> Instructions.transform_add_store_load_decls |> Normalise.insert_phi_assigns
+  |> Normalise.replace_stmts |> Builtins.transform_add_builtin_decls

--- a/test/cram/boogie_phis.il
+++ b/test/cram/boogie_phis.il
@@ -1,0 +1,25 @@
+prog entry @f;
+
+proc @f () -> ()
+[
+    block %a [
+        goto(%b, %c);
+    ];
+    block %b [
+        var x_1:bv64 := 0:bv64;
+        goto(%d);
+    ];
+    block %c [
+        var x_2:bv64 := 0:bv64;
+        goto(%d);
+    ];
+    block %d (
+        var x_3:bv64 := phi(
+            %c -> x_2:bv64,
+            %b -> x_1:bv64
+        )
+    ) [
+        assert eq(x_3,0:bv64);
+        return ();
+    ];
+];

--- a/test/cram/boogie_phis.sexp
+++ b/test/cram/boogie_phis.sexp
@@ -1,0 +1,3 @@
+(load-il "boogie_phis.il")
+(dump-il "out.il")
+(dump-boogie "out.bpl")

--- a/test/cram/boogie_phis.t
+++ b/test/cram/boogie_phis.t
@@ -1,0 +1,44 @@
+  $ bincaml script boogie_phis.sexp
+  (load-il boogie_phis.il)
+  (dump-il out.il)
+  (dump-boogie out.bpl)
+
+  $ cat ./out.il
+  proc @f()  -> () {  }
+    
+  
+  [
+     block %a [ goto (%b,%c); ];
+     block %c [ var x_2:bv64 := 0x0:bv64; goto (%d); ];
+     block %b [ var x_1:bv64 := 0x0:bv64; goto (%d); ];
+     block %d ( var x_3:bv64 := phi(%c -> x_2:bv64, %b -> x_1:bv64) ) [
+       assert eq(x_3:bv64, 0x0:bv64);
+       nop;
+       return;
+     ]
+  ];
+  prog entry @f;
+
+  $ cat ./out.bpl
+  
+  
+  procedure p$f();
+  implementation p$f() {
+    var x_2: bv64;
+    var x_3: bv64;
+    var x_1: bv64;
+    b#a:
+      goto b#b, b#c;
+    b#b:
+      x_1 := 0bv64;
+      x_3 := x_1;
+      goto b#d;
+    b#c:
+      x_2 := 0bv64;
+      x_3 := x_2;
+      goto b#d;
+    b#d:
+      assert (x_3 == 0bv64);
+      assert true;
+      return;
+  }

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -9,7 +9,14 @@
   concat.il))
 
 (cram
- (applies_to * \ expr_smt malloc_free memory_safety memory_interproc)
+ (applies_to
+  *
+  \
+  expr_smt
+  malloc_free
+  memory_safety
+  memory_interproc
+  memory_phis)
  (package bincaml)
  (deps
   loop_dfg.sexp
@@ -47,10 +54,12 @@
   ll_spec.sexp
   repeated_ssa.il
   repeated_ssa.sexp
+  boogie_phis.il
+  boogie_phis.sexp
   ../../bin/main.exe))
 
 (cram
- (applies_to malloc_free memory_safety memory_interproc)
+ (applies_to malloc_free memory_safety memory_interproc memory_phis)
  (package bincaml)
  (enabled_if
   (and %{bin-available:boogie} %{bin-available:cvc5}))
@@ -62,4 +71,6 @@
   ../../examples/memory/memory_interproc.il
   ./memory_interproc.sexp
   ../../examples/memory/memory_safety.il
-  ./memory_safety.sexp))
+  ./memory_safety.sexp
+  ./memory_phis.il
+  ./memory_phis.sexp))

--- a/test/cram/memory_phis.il
+++ b/test/cram/memory_phis.il
@@ -1,0 +1,126 @@
+memory shared $mem : (bv64 -> bv8);
+memory $stack : (bv64 -> bv8);
+
+proc @malloc(R0_in:bv64) -> (R0_out:bv64);
+proc @free(R0_in:bv64) -> ();
+
+prog entry @no_memory_leak;
+
+proc @no_memory_leak () -> () { .entrypoint=true; }
+[
+    block %a [
+        var (addr:bv64) := call @malloc(1:bv64);
+        goto(%b, %c);
+    ];
+    block %b [
+        call @free(addr);
+        goto(%d);
+    ];
+    block %c [
+        call @free(addr);
+        goto(%d);
+    ];
+    block %d [
+        return ();
+    ];
+];
+
+proc @memory_leak () -> () { .entrypoint=true; }
+[
+    block %a [
+        var (addr:bv64) := call @malloc(1:bv64);
+        goto(%b, %c);
+    ];
+    block %b [
+        call @free(addr);
+        goto(%d);
+    ];
+    block %c [
+        goto(%d);
+    ];
+    block %d [
+        return ();
+    ];
+];
+
+proc @no_null_pointer () -> () { .entrypoint=true; }
+[
+    block %a [
+        var addr:bv64 := 0:bv64;
+        goto(%b, %c);
+    ];
+    block %b [
+        var (addr:bv64) := call @malloc(1:bv64);
+        goto(%d);
+    ];
+    block %c [
+        var (addr:bv64) := call @malloc(1:bv64);
+        goto(%d);
+    ];
+    block %d [
+        store le $mem addr 0xff:bv8 8;
+        call @free(addr);
+        return ();
+    ];
+];
+
+proc @null_pointer () -> () { .entrypoint=true; }
+[
+    block %a [
+        var addr:bv64 := 0:bv64;
+        goto(%b, %c);
+    ];
+    block %b [
+        var (addr:bv64) := call @malloc(1:bv64);
+        goto(%d);
+    ];
+    block %c [
+        // Oops, forgot to allocate in a branch ...
+        // var (addr:bv64) := call @malloc(1:bv64);
+        goto(%d);
+    ];
+    block %d [
+        // ... resulting in writing to potentially unallocated memory
+        store le $mem addr 0xff:bv8 8;
+
+        // ... and also in freeing a null pointer
+        call @free(addr);
+        return ();
+    ];
+];
+
+proc @control_flow () -> () { .entrypoint=true; }
+[
+    block %a [
+        // Simulate a malloc that can fail, returning 0
+        goto(%b, %c);
+    ];
+    block %b [
+        var (addr:bv64) := call @malloc(1:bv64);
+        goto(%d);
+    ];
+    block %c [
+        var addr:bv64 := 0:bv64;
+        goto(%d);
+    ];
+    block %d [
+        // Branch on if the allocation was successful.
+        // Only use it if it was.
+        goto(%e, %f);
+    ];
+    block %e [
+        guard(neq(addr, 0:bv64));
+        store le $mem addr 0xff:bv8 8;
+        call @free(addr);
+        goto(%g);
+    ];
+    block %f [
+        guard(eq(addr, 0:bv64));
+        // allocation failed :(
+        // cannot do anything here.
+        goto(%g);
+    ];
+    block %g [
+        return ();
+    ];
+];

--- a/test/cram/memory_phis.sexp
+++ b/test/cram/memory_phis.sexp
@@ -1,0 +1,13 @@
+(load-il "memory_phis.il")
+
+(run-transforms "ssa")
+(run-transforms "split-memory-encoding")
+(run-transforms "memory-specification")
+
+(run-transforms "ssa")
+
+(run-transforms "linear-const")
+(run-transforms "linear-copy")
+
+(dump-il "after.il")
+(dump-boogie "out.bpl")

--- a/test/cram/memory_phis.t
+++ b/test/cram/memory_phis.t
@@ -1,0 +1,27 @@
+  $ bincaml script memory_phis.sexp
+  (load-il memory_phis.il)
+  (run-transforms ssa)
+  (run-transforms split-memory-encoding)
+  (run-transforms memory-specification)
+  (run-transforms ssa)
+  (run-transforms linear-const)
+  (run-transforms linear-copy)
+  (dump-il after.il)
+  (dump-boogie out.bpl)
+
+Expect 3 verified, 2 errors.
+  $ boogie ./out.bpl
+  ./out.bpl(185,5): Error: a postcondition could not be proved on this return path
+  ./out.bpl(153,3): Related location: this is the postcondition that could not be proved
+  Execution trace:
+      ./out.bpl(167,3): b#inputs
+      ./out.bpl(173,3): b#c
+      ./out.bpl(180,3): b#d
+  ./out.bpl(275,5): Error: a precondition for this call could not be proved
+  ./out.bpl(107,3): Related location: this is the precondition that could not be proved
+  Execution trace:
+      ./out.bpl(256,3): b#inputs
+      ./out.bpl(262,3): b#c
+      ./out.bpl(271,3): b#d
+  
+  Boogie program verifier finished with 3 verified, 2 errors


### PR DESCRIPTION
Got around to supporting phi nodes in the boogie backend.

Much like everything in the boogie prepass it kind of mangles the IR, but it seems to generate the correct assigns corresponding to phi nodes so yay! If only boogie had explicit phi nodes...

Also added 2 test cases. One for basic boogie gen, and then one more complicated one with a few memory encoding examples.