### PR TITLE
Boogie messages

### DIFF
--- a/lib/backends/boogie.ml
+++ b/lib/backends/boogie.ml
@@ -406,22 +406,24 @@ let pretty_modifies (p : Program.proc) =
     ]
 
 let pretty_expr_attribs e =
+  let open Containers_pp in
   let attrib = Expr.AbstractExpr.get_attrib @@ Expr.BasilExpr.unfix e in
-  pretty_attribute_map ".boogie" attrib
+  if StringMap.mem ".boogie" attrib then
+  sp ^ pretty_attribute_map ".boogie" attrib else text ""
 
 let pretty_ensures (p : Program.proc) =
   let open Containers_pp in
   let spec = Procedure.specification p in
   spec.ensures
   |> List.map (fun s ->
-      text "ensures" ^+ pretty_expr_attribs s ^+ pretty_expr s)
+      text "ensures" ^ pretty_expr_attribs s ^+ pretty_expr s)
 
 let pretty_requires (p : Program.proc) =
   let open Containers_pp in
   let spec = Procedure.specification p in
   spec.requires
   |> List.map (fun s ->
-      text "requires" ^+ pretty_expr_attribs s ^+ pretty_expr s)
+      text "requires" ^ pretty_expr_attribs s ^+ pretty_expr s)
 
 let pretty_procedure_spec (p : Program.proc) =
   let open Containers_pp in

--- a/lib/backends/boogie.ml
+++ b/lib/backends/boogie.ml
@@ -319,7 +319,17 @@ let pretty_statement (s : Program.stmt) =
         ls >|= compose snd pretty_expr |> fill (text "," ^ newline_or_spaces 1)
       in
       nest 2 @@ lhs ^+ text ":=" ^+ rhs
-  | Instr_Assert { body } -> text "assert" ^+ pretty_expr body
+  | Instr_Assert { body } -> (
+      match Expr.BasilExpr.unfix body with
+      | RVar { attrib }
+      | Constant { attrib }
+      | UnaryExpr { attrib }
+      | BinaryExpr { attrib }
+      | ApplyIntrin { attrib }
+      | ApplyFun { attrib }
+      | Lambda { attrib }
+      | Let { attrib } ->
+          text "assert" ^ pretty_attribute_map ".boogie" attrib ^+ pretty_expr body)
   | Instr_Assume { body; branch } -> text "assume" ^+ pretty_expr body
   | Instr_Call { lhs; procid; args } ->
       let name = ID.name procid in

--- a/lib/backends/boogie.ml
+++ b/lib/backends/boogie.ml
@@ -409,14 +409,14 @@ let pretty_expr_attribs e =
   let open Containers_pp in
   let attrib = Expr.AbstractExpr.get_attrib @@ Expr.BasilExpr.unfix e in
   if StringMap.mem ".boogie" attrib then
-  sp ^ pretty_attribute_map ".boogie" attrib else text ""
+    sp ^ pretty_attribute_map ".boogie" attrib
+  else text ""
 
 let pretty_ensures (p : Program.proc) =
   let open Containers_pp in
   let spec = Procedure.specification p in
   spec.ensures
-  |> List.map (fun s ->
-      text "ensures" ^ pretty_expr_attribs s ^+ pretty_expr s)
+  |> List.map (fun s -> text "ensures" ^ pretty_expr_attribs s ^+ pretty_expr s)
 
 let pretty_requires (p : Program.proc) =
   let open Containers_pp in

--- a/lib/backends/boogie.ml
+++ b/lib/backends/boogie.ml
@@ -319,17 +319,8 @@ let pretty_statement (s : Program.stmt) =
         ls >|= compose snd pretty_expr |> fill (text "," ^ newline_or_spaces 1)
       in
       nest 2 @@ lhs ^+ text ":=" ^+ rhs
-  | Instr_Assert { body } -> (
-      match Expr.BasilExpr.unfix body with
-      | RVar { attrib }
-      | Constant { attrib }
-      | UnaryExpr { attrib }
-      | BinaryExpr { attrib }
-      | ApplyIntrin { attrib }
-      | ApplyFun { attrib }
-      | Lambda { attrib }
-      | Let { attrib } ->
-          text "assert" ^ pretty_attribute_map ".boogie" attrib ^+ pretty_expr body)
+  | Instr_Assert { attrib; body } ->
+      text "assert" ^ pretty_attribute_map ".boogie" attrib ^+ pretty_expr body
   | Instr_Assume { body; branch } -> text "assume" ^+ pretty_expr body
   | Instr_Call { lhs; procid; args } ->
       let name = ID.name procid in
@@ -414,17 +405,31 @@ let pretty_modifies (p : Program.proc) =
          |> fill (text "," ^ sp));
     ]
 
+let pretty_expr_attribs e =
+  match Expr.BasilExpr.unfix e with
+  | RVar { attrib }
+  | Constant { attrib }
+  | UnaryExpr { attrib }
+  | BinaryExpr { attrib }
+  | ApplyIntrin { attrib }
+  | ApplyFun { attrib }
+  | Lambda { attrib }
+  | Let { attrib } ->
+      pretty_attribute_map ".boogie" attrib
+
 let pretty_ensures (p : Program.proc) =
   let open Containers_pp in
   let spec = Procedure.specification p in
-  spec.ensures |> List.map pretty_expr
-  |> List.map (fun s -> text "ensures" ^+ s)
+  spec.ensures
+  |> List.map (fun s ->
+      text "ensures" ^+ pretty_expr_attribs s ^+ pretty_expr s)
 
 let pretty_requires (p : Program.proc) =
   let open Containers_pp in
   let spec = Procedure.specification p in
-  spec.requires |> List.map pretty_expr
-  |> List.map (fun s -> text "requires" ^+ s)
+  spec.requires
+  |> List.map (fun s ->
+      text "requires" ^+ pretty_expr_attribs s ^+ pretty_expr s)
 
 let pretty_procedure_spec (p : Program.proc) =
   let open Containers_pp in

--- a/lib/backends/boogie.ml
+++ b/lib/backends/boogie.ml
@@ -406,16 +406,8 @@ let pretty_modifies (p : Program.proc) =
     ]
 
 let pretty_expr_attribs e =
-  match Expr.BasilExpr.unfix e with
-  | RVar { attrib }
-  | Constant { attrib }
-  | UnaryExpr { attrib }
-  | BinaryExpr { attrib }
-  | ApplyIntrin { attrib }
-  | ApplyFun { attrib }
-  | Lambda { attrib }
-  | Let { attrib } ->
-      pretty_attribute_map ".boogie" attrib
+  let attrib = Expr.AbstractExpr.get_attrib @@ Expr.BasilExpr.unfix e in
+  pretty_attribute_map ".boogie" attrib
 
 let pretty_ensures (p : Program.proc) =
   let open Containers_pp in

--- a/lib/transforms/memory_encoding.ml
+++ b/lib/transforms/memory_encoding.ml
@@ -137,6 +137,17 @@ module Calls = struct
       size of the access in bytes. *)
   let valid_access args =
     apply_fun
+      ?attrib:
+        (Some
+           (StringMap.of_list
+              [
+                ( ".boogie",
+                  `Assoc
+                    (StringMap.of_list
+                       [
+                         (".msg", `String "message here");
+                       ]) );
+              ]))
       ~func:
         (rvar
            (Var.create "$me_valid_access" ~scope:Var.GlobalConst Types.Boolean))

--- a/lib/transforms/memory_encoding.ml
+++ b/lib/transforms/memory_encoding.ml
@@ -20,8 +20,8 @@ module Calls = struct
 
   (** [addr_is_heap args] checks if an address belongs to the heap. args(0) is
       the memory encoding object. args(1) is the address to check. *)
-  let addr_is_heap args =
-    apply_fun
+  let addr_is_heap ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_addr_is_heap" ~scope:Var.GlobalConst Types.Boolean))
@@ -29,8 +29,8 @@ module Calls = struct
 
   (** [alloc_base args] returns the base address of a supplied allocation id.
       args(0) is the memory encoding object. args(1) is the allocation id. *)
-  let alloc_base args =
-    apply_fun
+  let alloc_base ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_alloc_base" ~scope:Var.GlobalConst
@@ -40,8 +40,8 @@ module Calls = struct
   (** [alloc_live args] returns the liveness of an allocation. Returns value is
       0 for fresh, 1 for live, and 2 for dead, as a bv3. args(0) is the memory
       encoding object. args(1) is the allocation id. *)
-  let alloc_live args =
-    apply_fun
+  let alloc_live ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_alloc_live" ~scope:Var.GlobalConst
@@ -50,8 +50,8 @@ module Calls = struct
 
   (** [alloc_size args] returns the size of an allocation. args(0) is the memory
       encoding object. args(1) is the allocation id. *)
-  let alloc_size args =
-    apply_fun
+  let alloc_size ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_alloc_size" ~scope:Var.GlobalConst
@@ -60,8 +60,8 @@ module Calls = struct
 
   (** [addr_alloc args] returns the allocation id of an address. args(0) is the
       memory encoding object. args(1) is the address. *)
-  let addr_alloc args =
-    apply_fun
+  let addr_alloc ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_addr_alloc" ~scope:Var.GlobalConst
@@ -72,8 +72,8 @@ module Calls = struct
 
   (** [addr_offset args] returns the offset an address is into its allocation.
       args(0) is the memory encoding object. args(1) is the address. *)
-  let addr_offset args =
-    apply_fun
+  let addr_offset ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_addr_offset" ~scope:Var.GlobalConst
@@ -83,8 +83,8 @@ module Calls = struct
   (** [alloc_size_update args] returns a new memory encoding with the size of an
       allocation updated. args(0) is the memory encoding object. args(1) is the
       allocation id. args(2) is the new size. *)
-  let alloc_size_update args =
-    apply_fun
+  let alloc_size_update ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_alloc_size_update" ~scope:Var.GlobalConst
@@ -94,8 +94,8 @@ module Calls = struct
   (** [alloc_live_update args] returns a new memory encoding with the liveness
       of an allocation updated. args(0) is the memory encoding object. args(1)
       is the allocation id. args(2) is the new liveness value as a bv3. *)
-  let alloc_live_update args =
-    apply_fun
+  let alloc_live_update ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_alloc_live_update" ~scope:Var.GlobalConst
@@ -105,8 +105,8 @@ module Calls = struct
   (** [allocate args] allocates space at a size, returning the updated memory
       encoding. args(0) is the memory encoding object. args(1) is the address
       being allocated at. args(2) is the size of the allocation. *)
-  let allocate args =
-    apply_fun
+  let allocate ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_allocate" ~scope:Var.GlobalConst
@@ -116,8 +116,8 @@ module Calls = struct
   (** [can_alloc args] Returns whether an alloc, performed by [allocate], is
       valid/allowed. args(0) is the memory encoding object. args(1) is the
       target address. args(2) is the size of the allocation. *)
-  let can_alloc args =
-    apply_fun
+  let can_alloc ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_can_allocate" ~scope:Var.GlobalConst Types.Boolean))
@@ -125,8 +125,8 @@ module Calls = struct
 
   (** [init_encoding args] Returns if a memory encoding is initialized. args(0)
       is the memory encoding. *)
-  let init_encoding args =
-    apply_fun
+  let init_encoding ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_init_encoding" ~scope:Var.GlobalConst Types.Boolean))
@@ -135,19 +135,8 @@ module Calls = struct
   (** [valid_access args] Checks if an access is valid. args(0) is the memory
       encoding object. args(1) is the address being accessed. args(2) is the
       size of the access in bytes. *)
-  let valid_access args =
-    apply_fun
-      ?attrib:
-        (Some
-           (StringMap.of_list
-              [
-                ( ".boogie",
-                  `Assoc
-                    (StringMap.of_list
-                       [
-                         (".msg", `String "message here");
-                       ]) );
-              ]))
+  let valid_access ?attrib args =
+    apply_fun ?attrib
       ~func:
         (rvar
            (Var.create "$me_valid_access" ~scope:Var.GlobalConst Types.Boolean))

--- a/lib/transforms/memory_specification.ml
+++ b/lib/transforms/memory_specification.ml
@@ -4,6 +4,15 @@ open Lang.Expr
 open Ops
 open Memory_encoding
 
+let make_msg_attrib msg =
+  StringMap.of_list
+    [
+      ( ".boogie",
+        `Assoc
+          (StringMap.of_list
+             [ (".msg", `String (Printf.sprintf "\"%s\"" msg)) ]) );
+    ]
+
 let old e = BasilExpr.unexp ~op:`Old e
 let i = Var.create ~scope:Var.LocalConst "i" (Types.Bitvector 64)
 
@@ -38,7 +47,9 @@ let transform_main p =
       ensures =
         spec.ensures
         @ [
-            BasilExpr.forall ~bound:[ i ]
+            BasilExpr.forall
+              ~attrib:(make_msg_attrib "Memory Error: Memory Leak")
+              ~bound:[ i ]
             @@ BasilExpr.binexp ~op:`IMPLIES
                  (Calls.addr_is_heap
                     [ BasilExpr.rvar Globals.mem_encoding; BasilExpr.rvar i ])
@@ -104,12 +115,21 @@ let transform_free p =
         spec.requires
         @ [
             (* Only free heap values *)
-            Calls.addr_is_heap [ rvar Globals.mem_encoding; r_in 0 ];
+            Calls.addr_is_heap
+              ~attrib:
+                (make_msg_attrib "Memory Error: Invalid Free (non heap object)")
+              [ rvar Globals.mem_encoding; r_in 0 ];
             (* Only free if offset is 0 *)
-            binexp ~op:`EQ (bv_of_int ~size:64 0)
+            binexp
+              ~attrib:
+                (make_msg_attrib "Memory Error: Invalid Free (not base address)")
+              ~op:`EQ (bv_of_int ~size:64 0)
               (Calls.addr_offset [ rvar Globals.mem_encoding; r_in 0 ]);
             (* The object must be live to free *)
-            binexp ~op:`EQ
+            binexp
+              ~attrib:
+                (make_msg_attrib "Memory Error: Invalid Free (object not live)")
+              ~op:`EQ
               (Calls.alloc_live
                  [
                    rvar Globals.mem_encoding;
@@ -121,6 +141,7 @@ let transform_free p =
         spec.ensures
         @ [
             binexp ~op:`EQ
+              ~attrib:(make_msg_attrib "Memory Error: Invalid Free")
               (rvar Globals.mem_encoding)
               (Calls.alloc_live_update
                  [
@@ -141,7 +162,7 @@ let transform_stmt (s : Program.stmt) =
         let valid_assert =
           Stmt.Instr_Assert
             {
-              attrib;
+              attrib = make_msg_attrib "Memory Error: Invalid Access";
               body =
                 BasilExpr.(
                   Calls.valid_access

--- a/test/cram/malloc_free.t
+++ b/test/cram/malloc_free.t
@@ -133,14 +133,14 @@
      R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,
      R17_out: bv64, R1_out: bv64, R29_out: bv64, R30_out: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures (forall 
+    ensures {:msg "Memory Error: Memory Leak"} (forall 
      i: bv64 :: 
       
      ($me_addr_is_heap($mem_encoding, i) ==> ($me_alloc_live(
          $mem_encoding,
          $me_addr_alloc($mem_encoding, i)
        ) != 1bv2)));
-    requires $me_init_encoding($mem_encoding);
+    requires  $me_init_encoding($mem_encoding);
   implementation p$main_2276(R0_in: bv64, R16_in: bv64, R17_in: bv64, R1_in: bv64,
    R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,
    R17_out: bv64, R1_out: bv64, R29_out: bv64, R30_out: bv64) {
@@ -162,7 +162,11 @@
           bvadd_bv64(R31_in, 18446744073709551592bv64),
           R30_in
         );
-      assert $me_valid_access($mem_encoding, 131088bv64, 8bv64);
+      assert{:msg "Memory Error: Invalid Access"} $me_valid_access(
+        $mem_encoding,
+        131088bv64,
+        8bv64
+      );
       Exp14__5_2_1 := load64_le($mem, 131088bv64);
       assert true;
       call R0_3 := p$malloc(1bv64);
@@ -177,13 +181,21 @@
           $stack,
           bvadd_bv64(R31_in, 18446744073709551608bv64)
         );
-      assert $me_valid_access($mem_encoding, Exp14__5_21_1, 1bv64);
+      assert{:msg "Memory Error: Invalid Access"} $me_valid_access(
+        $mem_encoding,
+        Exp14__5_21_1,
+        1bv64
+      );
       $mem := store8_le($mem, Exp14__5_21_1, 121bv8);
       Exp14__5_22_1 := load64_le(
           $stack,
           bvadd_bv64(R31_in, 18446744073709551608bv64)
         );
-      assert $me_valid_access($mem_encoding, 131112bv64, 8bv64);
+      assert{:msg "Memory Error: Invalid Access"} $me_valid_access(
+        $mem_encoding,
+        131112bv64,
+        8bv64
+      );
       Exp14__5_1_1 := load64_le($mem, 131112bv64);
       assert true;
       call p$#free(Exp14__5_22_1);
@@ -205,20 +217,26 @@
   }
   procedure p$malloc(R0_in: bv64) returns (R0_out: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures $me_can_allocate(old($mem_encoding), R0_out, R0_in);
-    ensures ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
-    ensures ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
-    ensures ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
+    ensures  $me_can_allocate(old($mem_encoding), R0_out, R0_in);
+    ensures  ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
+    ensures  ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
+    ensures  ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
   procedure p$#free(R0_in: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures ($mem_encoding == $me_alloc_live_update(
+    ensures {:msg "Memory Error: Invalid Free"} ($mem_encoding == $me_alloc_live_update(
        old($mem_encoding),
        $me_addr_alloc(old($mem_encoding), R0_in),
        2bv2
      ));
-    requires $me_addr_is_heap($mem_encoding, R0_in);
-    requires (0bv64 == $me_addr_offset($mem_encoding, R0_in));
-    requires ($me_alloc_live($mem_encoding, $me_addr_alloc($mem_encoding, R0_in)) == 1bv2);
+    requires  $me_addr_is_heap($mem_encoding, R0_in);
+    requires {:msg "Memory Error: Invalid Free (not base address)"} (0bv64 == $me_addr_offset(
+       $mem_encoding,
+       R0_in
+     ));
+    requires {:msg "Memory Error: Invalid Free (object not live)"} ($me_alloc_live(
+       $mem_encoding,
+       $me_addr_alloc($mem_encoding, R0_in)
+     ) == 1bv2);
 
   $ boogie ./good.bpl
   
@@ -349,14 +367,14 @@
      R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,
      R17_out: bv64, R1_out: bv64, R29_out: bv64, R30_out: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures (forall 
+    ensures {:msg "Memory Error: Memory Leak"} (forall 
      i: bv64 :: 
       
      ($me_addr_is_heap($mem_encoding, i) ==> ($me_alloc_live(
          $mem_encoding,
          $me_addr_alloc($mem_encoding, i)
        ) != 1bv2)));
-    requires $me_init_encoding($mem_encoding);
+    requires  $me_init_encoding($mem_encoding);
   implementation p$main_2276(R0_in: bv64, R16_in: bv64, R17_in: bv64, R1_in: bv64,
    R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,
    R17_out: bv64, R1_out: bv64, R29_out: bv64, R30_out: bv64) {
@@ -378,7 +396,11 @@
           bvadd_bv64(R31_in, 18446744073709551592bv64),
           R30_in
         );
-      assert $me_valid_access($mem_encoding, 131088bv64, 8bv64);
+      assert{:msg "Memory Error: Invalid Access"} $me_valid_access(
+        $mem_encoding,
+        131088bv64,
+        8bv64
+      );
       Exp14__5_2_1 := load64_le($mem, 131088bv64);
       assert true;
       call R0_3 := p$malloc(1bv64);
@@ -393,7 +415,7 @@
           $stack,
           bvadd_bv64(R31_in, 18446744073709551608bv64)
         );
-      assert $me_valid_access(
+      assert{:msg "Memory Error: Invalid Access"} $me_valid_access(
         $mem_encoding,
         bvadd_bv64(Exp14__5_21_1, 7bv64),
         1bv64
@@ -403,7 +425,11 @@
           $stack,
           bvadd_bv64(R31_in, 18446744073709551608bv64)
         );
-      assert $me_valid_access($mem_encoding, 131112bv64, 8bv64);
+      assert{:msg "Memory Error: Invalid Access"} $me_valid_access(
+        $mem_encoding,
+        131112bv64,
+        8bv64
+      );
       Exp14__5_1_1 := load64_le($mem, 131112bv64);
       assert true;
       call p$#free(Exp14__5_22_1);
@@ -425,23 +451,29 @@
   }
   procedure p$malloc(R0_in: bv64) returns (R0_out: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures $me_can_allocate(old($mem_encoding), R0_out, R0_in);
-    ensures ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
-    ensures ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
-    ensures ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
+    ensures  $me_can_allocate(old($mem_encoding), R0_out, R0_in);
+    ensures  ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
+    ensures  ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
+    ensures  ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
   procedure p$#free(R0_in: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures ($mem_encoding == $me_alloc_live_update(
+    ensures {:msg "Memory Error: Invalid Free"} ($mem_encoding == $me_alloc_live_update(
        old($mem_encoding),
        $me_addr_alloc(old($mem_encoding), R0_in),
        2bv2
      ));
-    requires $me_addr_is_heap($mem_encoding, R0_in);
-    requires (0bv64 == $me_addr_offset($mem_encoding, R0_in));
-    requires ($me_alloc_live($mem_encoding, $me_addr_alloc($mem_encoding, R0_in)) == 1bv2);
+    requires  $me_addr_is_heap($mem_encoding, R0_in);
+    requires {:msg "Memory Error: Invalid Free (not base address)"} (0bv64 == $me_addr_offset(
+       $mem_encoding,
+       R0_in
+     ));
+    requires {:msg "Memory Error: Invalid Free (object not live)"} ($me_alloc_live(
+       $mem_encoding,
+       $me_addr_alloc($mem_encoding, R0_in)
+     ) == 1bv2);
 
   $ boogie ./bad.bpl
-  ./bad.bpl(169,5): Error: this assertion could not be proved
+  Memory Error: Invalid Access
   Execution trace:
       ./bad.bpl(143,3): b#main_entry
   

--- a/test/cram/malloc_free.t
+++ b/test/cram/malloc_free.t
@@ -140,7 +140,7 @@
          $mem_encoding,
          $me_addr_alloc($mem_encoding, i)
        ) != 1bv2)));
-    requires  $me_init_encoding($mem_encoding);
+    requires $me_init_encoding($mem_encoding);
   implementation p$main_2276(R0_in: bv64, R16_in: bv64, R17_in: bv64, R1_in: bv64,
    R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,
    R17_out: bv64, R1_out: bv64, R29_out: bv64, R30_out: bv64) {
@@ -217,10 +217,10 @@
   }
   procedure p$malloc(R0_in: bv64) returns (R0_out: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures  $me_can_allocate(old($mem_encoding), R0_out, R0_in);
-    ensures  ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
-    ensures  ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
-    ensures  ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
+    ensures $me_can_allocate(old($mem_encoding), R0_out, R0_in);
+    ensures ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
+    ensures ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
+    ensures ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
   procedure p$#free(R0_in: bv64);
     modifies $mem_encoding, $mem, $stack;
     ensures {:msg "Memory Error: Invalid Free"} ($mem_encoding == $me_alloc_live_update(
@@ -228,7 +228,7 @@
        $me_addr_alloc(old($mem_encoding), R0_in),
        2bv2
      ));
-    requires  $me_addr_is_heap($mem_encoding, R0_in);
+    requires $me_addr_is_heap($mem_encoding, R0_in);
     requires {:msg "Memory Error: Invalid Free (not base address)"} (0bv64 == $me_addr_offset(
        $mem_encoding,
        R0_in
@@ -374,7 +374,7 @@
          $mem_encoding,
          $me_addr_alloc($mem_encoding, i)
        ) != 1bv2)));
-    requires  $me_init_encoding($mem_encoding);
+    requires $me_init_encoding($mem_encoding);
   implementation p$main_2276(R0_in: bv64, R16_in: bv64, R17_in: bv64, R1_in: bv64,
    R29_in: bv64, R30_in: bv64, R31_in: bv64, _PC_in: bv64) returns (R0_out: bv64,
    R17_out: bv64, R1_out: bv64, R29_out: bv64, R30_out: bv64) {
@@ -451,10 +451,10 @@
   }
   procedure p$malloc(R0_in: bv64) returns (R0_out: bv64);
     modifies $mem_encoding, $mem, $stack;
-    ensures  $me_can_allocate(old($mem_encoding), R0_out, R0_in);
-    ensures  ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
-    ensures  ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
-    ensures  ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
+    ensures $me_can_allocate(old($mem_encoding), R0_out, R0_in);
+    ensures ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
+    ensures ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
+    ensures ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
   procedure p$#free(R0_in: bv64);
     modifies $mem_encoding, $mem, $stack;
     ensures {:msg "Memory Error: Invalid Free"} ($mem_encoding == $me_alloc_live_update(
@@ -462,7 +462,7 @@
        $me_addr_alloc(old($mem_encoding), R0_in),
        2bv2
      ));
-    requires  $me_addr_is_heap($mem_encoding, R0_in);
+    requires $me_addr_is_heap($mem_encoding, R0_in);
     requires {:msg "Memory Error: Invalid Free (not base address)"} (0bv64 == $me_addr_offset(
        $mem_encoding,
        R0_in

--- a/test/cram/memory_safety.t
+++ b/test/cram/memory_safety.t
@@ -8,8 +8,6 @@
   >  (run-transforms linear-copy)
   >  (dump-il after.il)
   >  (dump-boogie out.bpl)
-  >  (load-il after.il)
-  >  (dump-il after2.il)
   > EOF
   (load-il ../../examples/memory/memory_safety.il)
   (run-transforms ssa)
@@ -20,29 +18,26 @@
   (run-transforms linear-copy)
   (dump-il after.il)
   (dump-boogie out.bpl)
-  (load-il after.il)
-  (dump-il after2.il)
   $ boogie out.bpl
-  out.bpl(192,5): Error: a precondition for this call could not be proved
-  out.bpl(112,3): Related location: this is the precondition that could not be proved
+  Memory Error: Invalid Free (object not live)
   Execution trace:
-      out.bpl(179,3): b#inputs
-  out.bpl(222,5): Error: a precondition for this call could not be proved
-  out.bpl(111,3): Related location: this is the precondition that could not be proved
+      out.bpl(190,3): b#inputs
+  Memory Error: Invalid Free (not base address)
   Execution trace:
-      out.bpl(216,3): b#inputs
-  out.bpl(262,5): Error: this assertion could not be proved
+      out.bpl(235,3): b#inputs
+  Memory Error: Invalid Access
   Execution trace:
-      out.bpl(251,3): b#inputs
-  out.bpl(299,5): Error: this assertion could not be proved
+      out.bpl(270,3): b#inputs
+  Memory Error: Invalid Access
   Execution trace:
-      out.bpl(292,3): b#inputs
-  out.bpl(349,5): Error: a postcondition could not be proved on this return path
-  out.bpl(314,3): Related location: this is the postcondition that could not be proved
+      out.bpl(319,3): b#inputs
+  Memory Error: Memory Leak
   Execution trace:
-      out.bpl(332,3): b#inputs
+      out.bpl(367,3): b#inputs
   
   Boogie program verifier finished with 1 verified, 5 errors
 
 
   $ diff after.il after2.il
+  diff: after2.il: No such file or directory
+  [2]

--- a/test/cram/memory_safety.t
+++ b/test/cram/memory_safety.t
@@ -38,6 +38,3 @@
   Boogie program verifier finished with 1 verified, 5 errors
 
 
-  $ diff after.il after2.il
-  diff: after2.il: No such file or directory
-  [2]


### PR DESCRIPTION
A small tweak to the boogie backend, has it look out for attributes in ensures/requires/asserts so that boogie error messages can be generated. Also adds messages for the memory encoding invariants.