### PR TITLE
Flat memory

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,0 +1,1 @@
+examples for github.com/agle/bincaml

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,1 +1,0 @@
-examples for github.com/agle/bincaml

--- a/lib/transforms/memory_encoding.ml
+++ b/lib/transforms/memory_encoding.ml
@@ -318,7 +318,7 @@ module FlatMemory : MemoryEncoding = struct
 
   let mem_encoding_type : Types.t =
     Types.Sort
-      ( "MemEncoding",
+      ( Globals.mem_encoding_typ_name,
         [
           Types.mk_variant "MemEncoding"
             [
@@ -333,7 +333,7 @@ module FlatMemory : MemoryEncoding = struct
                 (Types.Map (Types.Integer, Types.Bitvector 64));
               (* is an address on the heap *)
               Types.mk_field "addr_is_heap"
-                (Types.Map (Types.Bitvector 64, Types.Bitvector 2));
+                (Types.Map (Types.Bitvector 64, Types.Boolean));
               (* allocation of an address *)
               Types.mk_field "addr_alloc"
                 (Types.Map (Types.Bitvector 64, Types.Integer));
@@ -356,12 +356,10 @@ module FlatMemory : MemoryEncoding = struct
     let addr = Var.create "addr" ~scope:Var.LocalVar (Types.Bitvector 64)
     let size = Var.create "size" ~scope:Var.LocalVar (Types.Bitvector 64)
     let live = Var.create "live" ~scope:Var.LocalVar (Types.Bitvector 2)
-
-    let alloc_live_access =
-      unexp ~op:(`ReadField "alloc_live") (rvar mem_encoding)
-
-    let alloc_size_access =
-      unexp ~op:(`ReadField "alloc_size") (rvar mem_encoding)
+    let alloc_live_access_h me = unexp ~op:(`ReadField "alloc_live") (rvar me)
+    let alloc_live_access = alloc_live_access_h mem_encoding
+    let alloc_size_access_h me = unexp ~op:(`ReadField "alloc_size") (rvar me)
+    let alloc_size_access = alloc_size_access_h mem_encoding
 
     let alloc_base_access =
       unexp ~op:(`ReadField "alloc_base") (rvar mem_encoding)
@@ -376,18 +374,21 @@ module FlatMemory : MemoryEncoding = struct
       unexp ~op:(`ReadField "addr_offset") (rvar mem_encoding)
   end
 
-  let can_allocate_body : Lang.Program.e = boolconst false
+  let trigger e = [ [ e ] ]
+
+  let can_allocate_body : Lang.Program.e = boolconst true
 
   let alloc_size_body : Lang.Program.e =
-    binexp ~op:`MapAccess Locals.alloc_size_access (rvar Locals.addr)
+    binexp ~op:`MapAccess Locals.alloc_size_access (rvar Locals.alloc)
 
   let alloc_base_body : Lang.Program.e =
-    binexp ~op:`MapAccess Locals.alloc_base_access (rvar Locals.addr)
+    binexp ~op:`MapAccess Locals.alloc_base_access (rvar Locals.alloc)
 
-  let addr_alloc_body : Lang.Program.e = boolconst false
+  let addr_alloc_body : Lang.Program.e =
+    binexp ~op:`MapAccess Locals.addr_alloc_access (rvar Locals.addr)
 
   let alloc_live_body : Lang.Program.e =
-    binexp ~op:`MapAccess Locals.alloc_live_access (rvar Locals.addr)
+    binexp ~op:`MapAccess Locals.alloc_live_access (rvar Locals.alloc)
 
   let addr_offset_body : Lang.Program.e =
     binexp ~op:`MapAccess Locals.addr_offset_access (rvar Locals.addr)
@@ -405,9 +406,133 @@ module FlatMemory : MemoryEncoding = struct
       (applyintrin ~op:`MapUpdate
          [ Locals.alloc_live_access; rvar Locals.alloc; rvar Locals.live ])
 
-  let allocate_body : Lang.Program.e = applyintrin ~op:`AND []
-  let init_encoding_body : Lang.Program.e = boolconst false
-  let valid_access_body : Lang.Program.e = boolconst false
+  let allocate_body : Lang.Program.e =
+    let i = Var.create "i" ~scope:Var.LocalVar (Types.Bitvector 64) in
+    let in_bounds =
+      applyintrin ~op:`AND
+        [
+          binexp ~op:`BVULE (rvar Locals.addr) (rvar i);
+          binexp ~op:`BVULT (rvar i)
+            (binexp ~op:`BVADD (rvar Locals.addr) (rvar Locals.size));
+        ]
+    in
+    (* alloc for i and addr are the same *)
+    let same_alloc =
+      binexp ~op:`EQ
+        (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ])
+        (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar Locals.addr ])
+    in
+    applyintrin ~op:`AND
+      [
+        (* update addr_alloc for all pointers in the range [addr, addr+size)
+           to point to the old allocation counter. *)
+        forall ~bound:[ i ]
+          ~triggers:(trigger (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ]))
+          (binexp ~op:`IMPLIES in_bounds
+             (binexp ~op:`EQ
+                (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ])
+                (unexp ~op:(`ReadField "alloc_counter")
+                   (rvar Locals.mem_encoding))));
+        (* Preserve all other addr_alloc entries. *)
+        forall ~bound:[ i ]
+          ~triggers:(trigger (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ]))
+          (binexp ~op:`IMPLIES
+             (unexp ~op:`BoolNOT in_bounds)
+             (binexp ~op:`EQ
+                (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ])
+                (Calls.addr_alloc [ rvar Locals.mem_encoding; rvar i ])));
+        (* Update offsets for all pointers in allocation. *)
+        forall ~bound:[ i ]
+          ~triggers:(trigger (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ]))
+          (binexp ~op:`IMPLIES same_alloc
+             (binexp ~op:`EQ
+                (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ])
+                (binexp ~op:`BVSUB (rvar i) (rvar Locals.addr))));
+        (* Preserve all other addr offsets. *)
+        forall ~bound:[ i ]
+          ~triggers:(trigger (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ]))
+          (binexp ~op:`IMPLIES
+             (unexp ~op:`BoolNOT same_alloc)
+             (binexp ~op:`EQ
+                (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ])
+                (Calls.addr_offset [ rvar Locals.mem_encoding; rvar i ])));
+        (* Update the size of the allocation. *)
+        binexp ~op:`EQ
+          (Locals.alloc_size_access_h Locals.mem_encoding_out)
+          (applyintrin ~op:`MapUpdate
+             [
+               Locals.alloc_size_access;
+               Calls.addr_alloc
+                 [ rvar Locals.mem_encoding_out; rvar Locals.addr ];
+               rvar Locals.size;
+             ]);
+        (* Update the liveness of the allocation. *)
+        binexp ~op:`EQ
+          (Locals.alloc_live_access_h Locals.mem_encoding_out)
+          (applyintrin ~op:`MapUpdate
+             [
+               Locals.alloc_live_access;
+               Calls.addr_alloc
+                 [ rvar Locals.mem_encoding_out; rvar Locals.addr ];
+               bvconst live;
+             ]);
+        (* The allocation at addr was fresh. *)
+        binexp ~op:`EQ
+          (Calls.alloc_live
+             [
+               rvar Locals.mem_encoding;
+               Calls.addr_alloc
+                 [ rvar Locals.mem_encoding_out; rvar Locals.addr ];
+             ])
+          (bvconst fresh);
+        (* The allocation at addr was/is on the heap. *)
+        Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar Locals.addr ];
+        (* addr_is_heap is unchanged. *)
+        binexp ~op:`EQ (unexp ~op:(`ReadField "addr_is_heap") (rvar Locals.mem_encoding)) (unexp ~op:(`ReadField "addr_is_heap") (rvar Locals.mem_encoding_out))
+      ]
+
+  let init_encoding_body : Lang.Program.e =
+    let o = Var.create "o" ~scope:Var.LocalVar Types.Integer in
+    let i = Var.create "i" ~scope:Var.LocalVar (Types.Bitvector 64) in
+    applyintrin ~op:`AND
+      [
+        (* allocation counter starts at 0 *)
+        binexp ~op:`EQ
+          (unexp ~op:(`ReadField "alloc_counter") (rvar Locals.mem_encoding))
+          (intconst @@ Z.of_int 0);
+        (* all objects are initially fresh *)
+        forall ~bound:[ o ]
+          ~triggers:(trigger (Calls.alloc_live [ rvar Locals.mem_encoding; rvar o ]))
+          (binexp ~op:`EQ
+             (Calls.alloc_live [ rvar Locals.mem_encoding; rvar o ])
+             (bvconst fresh));
+        (* stack/heap separation, TODO: compute this smartly *)
+        forall ~bound:[ i ]
+          ~triggers:(trigger (Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar i ]))
+          (binexp ~op:`EQ
+             (Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar i ])
+             (unexp ~op:`BoolNOT @@ binexp ~op:`BVULE (rvar i) (bv_of_int ~size:64 100000000)));
+      ]
+
+  let valid_access_body : Lang.Program.e =
+    let alloc =
+      Calls.addr_alloc [ rvar Locals.mem_encoding; rvar Locals.addr ]
+    in
+    let offset =
+      Calls.addr_offset [ rvar Locals.mem_encoding; rvar Locals.addr ]
+    in
+    binexp ~op:`IMPLIES
+      (Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar Locals.addr ])
+      (applyintrin ~op:`AND
+         [
+           binexp ~op:`EQ
+             (Calls.alloc_live [ rvar Locals.mem_encoding; alloc ])
+             (bvconst live);
+           binexp ~op:`BVULE (bv_of_int 0 ~size:64) offset;
+           binexp ~op:`BVULE
+             (binexp ~op:`BVADD (rvar Locals.size) offset)
+             (Calls.alloc_size [ rvar Locals.mem_encoding; alloc ]);
+         ])
 end
 
 module SplitMemory : MemoryEncoding = struct

--- a/lib/transforms/memory_encoding.ml
+++ b/lib/transforms/memory_encoding.ml
@@ -375,7 +375,6 @@ module FlatMemory : MemoryEncoding = struct
   end
 
   let trigger e = [ [ e ] ]
-
   let can_allocate_body : Lang.Program.e = boolconst true
 
   let alloc_size_body : Lang.Program.e =
@@ -427,7 +426,9 @@ module FlatMemory : MemoryEncoding = struct
         (* update addr_alloc for all pointers in the range [addr, addr+size)
            to point to the old allocation counter. *)
         forall ~bound:[ i ]
-          ~triggers:(trigger (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ]))
+          ~triggers:
+            (trigger
+               (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ]))
           (binexp ~op:`IMPLIES in_bounds
              (binexp ~op:`EQ
                 (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ])
@@ -435,7 +436,9 @@ module FlatMemory : MemoryEncoding = struct
                    (rvar Locals.mem_encoding))));
         (* Preserve all other addr_alloc entries. *)
         forall ~bound:[ i ]
-          ~triggers:(trigger (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ]))
+          ~triggers:
+            (trigger
+               (Calls.addr_alloc [ rvar Locals.mem_encoding_out; rvar i ]))
           (binexp ~op:`IMPLIES
              (unexp ~op:`BoolNOT in_bounds)
              (binexp ~op:`EQ
@@ -443,14 +446,18 @@ module FlatMemory : MemoryEncoding = struct
                 (Calls.addr_alloc [ rvar Locals.mem_encoding; rvar i ])));
         (* Update offsets for all pointers in allocation. *)
         forall ~bound:[ i ]
-          ~triggers:(trigger (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ]))
+          ~triggers:
+            (trigger
+               (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ]))
           (binexp ~op:`IMPLIES same_alloc
              (binexp ~op:`EQ
                 (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ])
                 (binexp ~op:`BVSUB (rvar i) (rvar Locals.addr))));
         (* Preserve all other addr offsets. *)
         forall ~bound:[ i ]
-          ~triggers:(trigger (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ]))
+          ~triggers:
+            (trigger
+               (Calls.addr_offset [ rvar Locals.mem_encoding_out; rvar i ]))
           (binexp ~op:`IMPLIES
              (unexp ~op:`BoolNOT same_alloc)
              (binexp ~op:`EQ
@@ -488,7 +495,9 @@ module FlatMemory : MemoryEncoding = struct
         (* The allocation at addr was/is on the heap. *)
         Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar Locals.addr ];
         (* addr_is_heap is unchanged. *)
-        binexp ~op:`EQ (unexp ~op:(`ReadField "addr_is_heap") (rvar Locals.mem_encoding)) (unexp ~op:(`ReadField "addr_is_heap") (rvar Locals.mem_encoding_out))
+        binexp ~op:`EQ
+          (unexp ~op:(`ReadField "addr_is_heap") (rvar Locals.mem_encoding))
+          (unexp ~op:(`ReadField "addr_is_heap") (rvar Locals.mem_encoding_out));
       ]
 
   let init_encoding_body : Lang.Program.e =
@@ -502,16 +511,19 @@ module FlatMemory : MemoryEncoding = struct
           (intconst @@ Z.of_int 0);
         (* all objects are initially fresh *)
         forall ~bound:[ o ]
-          ~triggers:(trigger (Calls.alloc_live [ rvar Locals.mem_encoding; rvar o ]))
+          ~triggers:
+            (trigger (Calls.alloc_live [ rvar Locals.mem_encoding; rvar o ]))
           (binexp ~op:`EQ
              (Calls.alloc_live [ rvar Locals.mem_encoding; rvar o ])
              (bvconst fresh));
         (* stack/heap separation, TODO: compute this smartly *)
         forall ~bound:[ i ]
-          ~triggers:(trigger (Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar i ]))
+          ~triggers:
+            (trigger (Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar i ]))
           (binexp ~op:`EQ
              (Calls.addr_is_heap [ rvar Locals.mem_encoding; rvar i ])
-             (unexp ~op:`BoolNOT @@ binexp ~op:`BVULE (rvar i) (bv_of_int ~size:64 100000000)));
+             (unexp ~op:`BoolNOT
+             @@ binexp ~op:`BVULE (rvar i) (bv_of_int ~size:64 100000000)));
       ]
 
   let valid_access_body : Lang.Program.e =

--- a/lib/transforms/memory_encoding.ml
+++ b/lib/transforms/memory_encoding.ml
@@ -68,8 +68,6 @@ module Calls = struct
               (Types.Bitvector 64)))
       args
 
-  (* (Types.curry [Types.Bitvector 64; Types.Bitvector 64; Types.Variable "MemEncoding";] Types.Boolean))) *)
-
   (** [addr_offset args] returns the offset an address is into its allocation.
       args(0) is the memory encoding object. args(1) is the address. *)
   let addr_offset ?attrib args =
@@ -102,15 +100,13 @@ module Calls = struct
               Globals.mem_encoding_typ))
       args
 
-  (** [allocate args] allocates space at a size, returning the updated memory
-      encoding. args(0) is the memory encoding object. args(1) is the address
-      being allocated at. args(2) is the size of the allocation. *)
+  (** [allocate args] allocates space at a size. args(0) is the memory encoding
+      object, args(1) is the updated encoding. args(2) is the address being
+      allocated at. args(3) is the size of the allocation. *)
   let allocate ?attrib args =
     apply_fun ?attrib
       ~func:
-        (rvar
-           (Var.create "$me_allocate" ~scope:Var.GlobalConst
-              Globals.mem_encoding_typ))
+        (rvar (Var.create "$me_allocate" ~scope:Var.GlobalConst Types.Boolean))
       args
 
   (** [can_alloc args] Returns whether an alloc, performed by [allocate], is
@@ -146,6 +142,7 @@ end
 module type MemoryEncoding = sig
   module Locals : sig
     val mem_encoding : Var.t
+    val mem_encoding_out : Var.t
     val alloc : Var.t
     val addr : Var.t
     val size : Var.t
@@ -226,7 +223,10 @@ module MemoryEncoder (Encoding : MemoryEncoding) = struct
   let add_allocate p =
     add_decl ~attrib p "me_allocate"
       [
-        Encoding.Locals.mem_encoding; Encoding.Locals.addr; Encoding.Locals.size;
+        Encoding.Locals.mem_encoding;
+        Encoding.Locals.mem_encoding_out;
+        Encoding.Locals.addr;
+        Encoding.Locals.size;
       ]
       Encoding.allocate_body
 
@@ -317,28 +317,95 @@ module FlatMemory : MemoryEncoding = struct
   open BasilExpr
 
   let mem_encoding_type : Types.t =
-    Types.Sort ("MemEncoding", [ Types.mk_variant "MemEncoding" [] ])
+    Types.Sort
+      ( "MemEncoding",
+        [
+          Types.mk_variant "MemEncoding"
+            [
+              (* liveness of an allocation *)
+              Types.mk_field "alloc_live"
+                (Types.Map (Types.Integer, Types.Bitvector 2));
+              (* size of an allocation *)
+              Types.mk_field "alloc_size"
+                (Types.Map (Types.Integer, Types.Bitvector 64));
+              (* allocation base address *)
+              Types.mk_field "alloc_base"
+                (Types.Map (Types.Integer, Types.Bitvector 64));
+              (* is an address on the heap *)
+              Types.mk_field "addr_is_heap"
+                (Types.Map (Types.Bitvector 64, Types.Bitvector 2));
+              (* allocation of an address *)
+              Types.mk_field "addr_alloc"
+                (Types.Map (Types.Bitvector 64, Types.Integer));
+              (* offset of an address into its allocation *)
+              Types.mk_field "addr_offset"
+                (Types.Map (Types.Bitvector 64, Types.Bitvector 64));
+              (* allocation counter *)
+              Types.mk_field "alloc_counter" Types.Integer;
+            ];
+        ] )
 
   module Locals = struct
     let mem_encoding : Var.t =
       Var.create "mem_encoding" ~scope:Var.LocalVar mem_encoding_type
 
-    let alloc = Var.create "alloc" ~scope:Var.LocalVar (Types.Bitvector 64)
+    let mem_encoding_out : Var.t =
+      Var.create "mem_encoding_out" ~scope:Var.LocalVar mem_encoding_type
+
+    let alloc = Var.create "alloc" ~scope:Var.LocalVar Types.Integer
     let addr = Var.create "addr" ~scope:Var.LocalVar (Types.Bitvector 64)
     let size = Var.create "size" ~scope:Var.LocalVar (Types.Bitvector 64)
     let live = Var.create "live" ~scope:Var.LocalVar (Types.Bitvector 2)
+
+    let alloc_live_access =
+      unexp ~op:(`ReadField "alloc_live") (rvar mem_encoding)
+
+    let alloc_size_access =
+      unexp ~op:(`ReadField "alloc_size") (rvar mem_encoding)
+
+    let alloc_base_access =
+      unexp ~op:(`ReadField "alloc_base") (rvar mem_encoding)
+
+    let addr_is_heap_access =
+      unexp ~op:(`ReadField "addr_is_heap") (rvar mem_encoding)
+
+    let addr_alloc_access =
+      unexp ~op:(`ReadField "addr_alloc") (rvar mem_encoding)
+
+    let addr_offset_access =
+      unexp ~op:(`ReadField "addr_offset") (rvar mem_encoding)
   end
 
   let can_allocate_body : Lang.Program.e = boolconst false
-  let alloc_size_body : Lang.Program.e = boolconst false
-  let alloc_base_body : Lang.Program.e = boolconst false
+
+  let alloc_size_body : Lang.Program.e =
+    binexp ~op:`MapAccess Locals.alloc_size_access (rvar Locals.addr)
+
+  let alloc_base_body : Lang.Program.e =
+    binexp ~op:`MapAccess Locals.alloc_base_access (rvar Locals.addr)
+
   let addr_alloc_body : Lang.Program.e = boolconst false
-  let alloc_live_body : Lang.Program.e = boolconst false
-  let addr_offset_body : Lang.Program.e = boolconst false
-  let addr_is_heap_body : Lang.Program.e = boolconst false
-  let alloc_size_update_body : Lang.Program.e = boolconst false
-  let alloc_live_update_body : Lang.Program.e = boolconst false
-  let allocate_body : Lang.Program.e = boolconst false
+
+  let alloc_live_body : Lang.Program.e =
+    binexp ~op:`MapAccess Locals.alloc_live_access (rvar Locals.addr)
+
+  let addr_offset_body : Lang.Program.e =
+    binexp ~op:`MapAccess Locals.addr_offset_access (rvar Locals.addr)
+
+  let addr_is_heap_body : Lang.Program.e =
+    binexp ~op:`MapAccess Locals.addr_is_heap_access (rvar Locals.addr)
+
+  let alloc_size_update_body : Lang.Program.e =
+    binexp ~op:(`WriteField "alloc_size") (rvar Locals.mem_encoding)
+      (applyintrin ~op:`MapUpdate
+         [ Locals.alloc_size_access; rvar Locals.alloc; rvar Locals.size ])
+
+  let alloc_live_update_body : Lang.Program.e =
+    binexp ~op:(`WriteField "alloc_live") (rvar Locals.mem_encoding)
+      (applyintrin ~op:`MapUpdate
+         [ Locals.alloc_live_access; rvar Locals.alloc; rvar Locals.live ])
+
+  let allocate_body : Lang.Program.e = applyintrin ~op:`AND []
   let init_encoding_body : Lang.Program.e = boolconst false
   let valid_access_body : Lang.Program.e = boolconst false
 end
@@ -367,6 +434,9 @@ module SplitMemory : MemoryEncoding = struct
   module Locals = struct
     let mem_encoding =
       Var.create "mem_encoding" ~scope:Var.LocalVar mem_encoding_type
+
+    let mem_encoding_out : Var.t =
+      Var.create "mem_encoding_out" ~scope:Var.LocalVar mem_encoding_type
 
     let alloc = Var.create "alloc" ~scope:Var.LocalVar (Types.Bitvector 64)
     let addr = Var.create "addr" ~scope:Var.LocalVar (Types.Bitvector 64)
@@ -440,13 +510,17 @@ module SplitMemory : MemoryEncoding = struct
       Calls.addr_alloc [ rvar Locals.mem_encoding; rvar Locals.addr ]
     in
 
-    Calls.alloc_size_update
-      [
-        Calls.alloc_live_update
-          [ rvar Locals.mem_encoding; alloc; bvconst live ];
-        alloc;
-        rvar Locals.size;
-      ]
+    let updated =
+      Calls.alloc_size_update
+        [
+          Calls.alloc_live_update
+            [ rvar Locals.mem_encoding; alloc; bvconst live ];
+          alloc;
+          rvar Locals.size;
+        ]
+    in
+
+    binexp ~op:`EQ updated (rvar Locals.mem_encoding_out)
 
   let init_encoding_body =
     let i = Var.create "i" ~scope:Var.LocalVar (Types.Bitvector 64) in

--- a/lib/transforms/memory_specification.ml
+++ b/lib/transforms/memory_specification.ml
@@ -90,8 +90,13 @@ let transform_malloc p =
                  ])
               (r_out 0);
             (* Update the memory encoding: *)
-              (Calls.allocate
-                 [ old @@ rvar Globals.mem_encoding; rvar Globals.mem_encoding; r_out 0; r_in 0 ]);
+            Calls.allocate
+              [
+                old @@ rvar Globals.mem_encoding;
+                rvar Globals.mem_encoding;
+                r_out 0;
+                r_in 0;
+              ];
           ];
       modifies_globs = spec.modifies_globs @ [ Globals.mem_encoding ];
       captures_globs = spec.captures_globs @ [ Globals.mem_encoding ];

--- a/lib/transforms/memory_specification.ml
+++ b/lib/transforms/memory_specification.ml
@@ -90,10 +90,8 @@ let transform_malloc p =
                  ])
               (r_out 0);
             (* Update the memory encoding: *)
-            binexp ~op:`EQ
-              (rvar Globals.mem_encoding)
               (Calls.allocate
-                 [ old @@ rvar Globals.mem_encoding; r_out 0; r_in 0 ]);
+                 [ old @@ rvar Globals.mem_encoding; rvar Globals.mem_encoding; r_out 0; r_in 0 ]);
           ];
       modifies_globs = spec.modifies_globs @ [ Globals.mem_encoding ];
       captures_globs = spec.captures_globs @ [ Globals.mem_encoding ];

--- a/test/cram/malloc_free.t
+++ b/test/cram/malloc_free.t
@@ -48,16 +48,16 @@
   function {:extern } {:inline } $me_alloc_live_update(mem_encoding: memory_encoding, alloc: bv64, live: bv2) returns (memory_encoding) {
     mem_encoding->(alloc_live := mem_encoding->alloc_live[alloc := live])
   }
-  function {:extern } {:inline } $me_allocate(mem_encoding: memory_encoding, addr: bv64, size: bv64) returns (memory_encoding) {
-    $me_alloc_size_update(
-      $me_alloc_live_update(
-        mem_encoding,
-        $me_addr_alloc(mem_encoding, addr),
-        1bv2
-      ),
-      $me_addr_alloc(mem_encoding, addr),
-      size
-    )
+  function {:extern } {:inline } $me_allocate(mem_encoding: memory_encoding, mem_encoding_out: memory_encoding, addr: bv64, size: bv64) returns (bool) {
+    ($me_alloc_size_update(
+       $me_alloc_live_update(
+         mem_encoding,
+         $me_addr_alloc(mem_encoding, addr),
+         1bv2
+       ),
+       $me_addr_alloc(mem_encoding, addr),
+       size
+     ) == mem_encoding_out)
   }
   function {:extern } {:inline } $me_init_encoding(mem_encoding: memory_encoding) returns (bool) {
     (((forall 
@@ -220,7 +220,7 @@
     ensures $me_can_allocate(old($mem_encoding), R0_out, R0_in);
     ensures ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
     ensures ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
-    ensures ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
+    ensures $me_allocate(old($mem_encoding), $mem_encoding, R0_out, R0_in);
   procedure p$#free(R0_in: bv64);
     modifies $mem_encoding, $mem, $stack;
     ensures {:msg "Memory Error: Invalid Free"} ($mem_encoding == $me_alloc_live_update(
@@ -285,16 +285,16 @@
   function {:extern } {:inline } $me_alloc_live_update(mem_encoding: memory_encoding, alloc: bv64, live: bv2) returns (memory_encoding) {
     mem_encoding->(alloc_live := mem_encoding->alloc_live[alloc := live])
   }
-  function {:extern } {:inline } $me_allocate(mem_encoding: memory_encoding, addr: bv64, size: bv64) returns (memory_encoding) {
-    $me_alloc_size_update(
-      $me_alloc_live_update(
-        mem_encoding,
-        $me_addr_alloc(mem_encoding, addr),
-        1bv2
-      ),
-      $me_addr_alloc(mem_encoding, addr),
-      size
-    )
+  function {:extern } {:inline } $me_allocate(mem_encoding: memory_encoding, mem_encoding_out: memory_encoding, addr: bv64, size: bv64) returns (bool) {
+    ($me_alloc_size_update(
+       $me_alloc_live_update(
+         mem_encoding,
+         $me_addr_alloc(mem_encoding, addr),
+         1bv2
+       ),
+       $me_addr_alloc(mem_encoding, addr),
+       size
+     ) == mem_encoding_out)
   }
   function {:extern } {:inline } $me_init_encoding(mem_encoding: memory_encoding) returns (bool) {
     (((forall 
@@ -457,7 +457,7 @@
     ensures $me_can_allocate(old($mem_encoding), R0_out, R0_in);
     ensures ($me_addr_offset($mem_encoding, R0_out) == 0bv64);
     ensures ($me_alloc_base($mem_encoding, $me_addr_alloc($mem_encoding, R0_out)) == R0_out);
-    ensures ($mem_encoding == $me_allocate(old($mem_encoding), R0_out, R0_in));
+    ensures $me_allocate(old($mem_encoding), $mem_encoding, R0_out, R0_in);
   procedure p$#free(R0_in: bv64);
     modifies $mem_encoding, $mem, $stack;
     ensures {:msg "Memory Error: Invalid Free"} ($mem_encoding == $me_alloc_live_update(

--- a/test/cram/memory_interproc.t
+++ b/test/cram/memory_interproc.t
@@ -1,4 +1,15 @@
-  $ bincaml script memory_interproc.sexp
+  $ cat << EOF | bincaml script -
+  > (load-il "../../examples/memory/memory_interproc.il")
+  > (run-transforms "ssa")
+  > (run-transforms "split-memory-encoding")
+  > (run-transforms "memory-specification")
+  > (run-transforms "ssa")
+  > (run-transforms "linear-const")
+  > (run-transforms "linear-copy")
+  > (run-transforms "inter-function-summaries")
+  > (dump-il "after.il")
+  > (dump-boogie "out.bpl")
+  > EOF
   (load-il ../../examples/memory/memory_interproc.il)
   (run-transforms ssa)
   (run-transforms split-memory-encoding)
@@ -13,3 +24,33 @@
   $ boogie out.bpl
   
   Boogie program verifier finished with 2 verified, 0 errors
+
+  $ cat << EOF | bincaml script -
+  > (load-il "../../examples/memory/memory_interproc.il")
+  > (run-transforms "ssa")
+  > (run-transforms "flat-memory-encoding")
+  > (run-transforms "memory-specification")
+  > (run-transforms "ssa")
+  > (run-transforms "linear-const")
+  > (run-transforms "linear-copy")
+  > (run-transforms "inter-function-summaries")
+  > (dump-il "after.il")
+  > (dump-boogie "out.bpl")
+  > EOF
+  (load-il ../../examples/memory/memory_interproc.il)
+  (run-transforms ssa)
+  (run-transforms flat-memory-encoding)
+  (run-transforms memory-specification)
+  (run-transforms ssa)
+  (run-transforms linear-const)
+  (run-transforms linear-copy)
+  (run-transforms inter-function-summaries)
+  (dump-il after.il)
+  (dump-boogie out.bpl)
+
+  $ boogie out.bpl
+  out.bpl(293,5): Error: this assertion could not be proved
+  Execution trace:
+      out.bpl(282,3): b#inputs
+  
+  Boogie program verifier finished with 1 verified, 1 error

--- a/test/cram/memory_interproc.t
+++ b/test/cram/memory_interproc.t
@@ -19,8 +19,8 @@
   (run-transforms linear-const)
   (run-transforms linear-copy)
   (run-transforms inter-function-summaries)
+  (run-transforms dynamic-single-assignment)
   (dump-il after.il)
-  (run-transforms flatten-phis)
   (dump-boogie out.bpl)
   $ boogie out.bpl
   
@@ -47,6 +47,7 @@
   (run-transforms linear-const)
   (run-transforms linear-copy)
   (run-transforms inter-function-summaries)
+  (run-transforms dynamic-single-assignment)
   (dump-il after.il)
   (dump-boogie out.bpl)
 

--- a/test/cram/memory_interproc.t
+++ b/test/cram/memory_interproc.t
@@ -7,6 +7,7 @@
   > (run-transforms "linear-const")
   > (run-transforms "linear-copy")
   > (run-transforms "inter-function-summaries")
+  > (run-transforms "dynamic-single-assignment")
   > (dump-il "after.il")
   > (dump-boogie "out.bpl")
   > EOF
@@ -34,6 +35,7 @@
   > (run-transforms "linear-const")
   > (run-transforms "linear-copy")
   > (run-transforms "inter-function-summaries")
+  > (run-transforms "dynamic-single-assignment")
   > (dump-il "after.il")
   > (dump-boogie "out.bpl")
   > EOF

--- a/test/cram/memory_interproc.t
+++ b/test/cram/memory_interproc.t
@@ -49,8 +49,8 @@
   (dump-boogie out.bpl)
 
   $ boogie out.bpl
-  out.bpl(293,5): Error: this assertion could not be proved
+  out.bpl(296,5): Error: this assertion could not be proved
   Execution trace:
-      out.bpl(282,3): b#inputs
+      out.bpl(285,3): b#inputs
   
   Boogie program verifier finished with 1 verified, 1 error

--- a/test/cram/memory_safety.t
+++ b/test/cram/memory_safety.t
@@ -39,4 +39,53 @@
   
   Boogie program verifier finished with 1 verified, 5 errors
 
+  $ cat << EOF | bincaml script -
+  >  (load-il ../../examples/memory/memory_safety.il)
+  >  (run-transforms ssa)
+  >  (run-transforms flat-memory-encoding)
+  >  (run-transforms memory-specification)
+  >  (run-transforms ssa)
+  >  (run-transforms linear-const)
+  >  (run-transforms linear-copy)
+  >  (dump-il after.il)
+  >  (dump-boogie out.bpl)
+  > EOF
+  (load-il ../../examples/memory/memory_safety.il)
+  (run-transforms ssa)
+  (run-transforms flat-memory-encoding)
+  (run-transforms memory-specification)
+  (run-transforms ssa)
+  (run-transforms linear-const)
+  (run-transforms linear-copy)
+  (dump-il after.il)
+  (dump-boogie out.bpl)
 
+  $ boogie out.bpl
+  out.bpl(228,5): Error: a precondition for this call could not be proved
+  out.bpl(148,3): Related location: this is the precondition that could not be proved
+  Execution trace:
+      out.bpl(215,3): b#inputs
+  out.bpl(258,5): Error: a precondition for this call could not be proved
+  out.bpl(147,3): Related location: this is the precondition that could not be proved
+  Execution trace:
+      out.bpl(252,3): b#inputs
+  out.bpl(258,5): Error: a precondition for this call could not be proved
+  out.bpl(148,3): Related location: this is the precondition that could not be proved
+  Execution trace:
+      out.bpl(252,3): b#inputs
+  out.bpl(258,5): Error: a precondition for this call could not be proved
+  out.bpl(146,3): Related location: this is the precondition that could not be proved
+  Execution trace:
+      out.bpl(252,3): b#inputs
+  out.bpl(298,5): Error: this assertion could not be proved
+  Execution trace:
+      out.bpl(287,3): b#inputs
+  out.bpl(335,5): Error: this assertion could not be proved
+  Execution trace:
+      out.bpl(328,3): b#inputs
+  out.bpl(385,5): Error: a postcondition could not be proved on this return path
+  out.bpl(350,3): Related location: this is the postcondition that could not be proved
+  Execution trace:
+      out.bpl(368,3): b#inputs
+  
+  Boogie program verifier finished with 1 verified, 7 errors

--- a/test/cram/memory_safety.t
+++ b/test/cram/memory_safety.t
@@ -58,6 +58,7 @@
   (run-transforms ssa)
   (run-transforms linear-const)
   (run-transforms linear-copy)
+  (run-transforms dynamic-single-assignment)
   (dump-il after.il)
   (dump-boogie out.bpl)
 

--- a/test/cram/memory_safety.t
+++ b/test/cram/memory_safety.t
@@ -47,6 +47,7 @@
   >  (run-transforms ssa)
   >  (run-transforms linear-const)
   >  (run-transforms linear-copy)
+  >  (run-transforms "dynamic-single-assignment")
   >  (dump-il after.il)
   >  (dump-boogie out.bpl)
   > EOF

--- a/test/cram/memory_safety.t
+++ b/test/cram/memory_safety.t
@@ -61,31 +61,27 @@
   (dump-boogie out.bpl)
 
   $ boogie out.bpl
-  out.bpl(228,5): Error: a precondition for this call could not be proved
-  out.bpl(148,3): Related location: this is the precondition that could not be proved
+  Memory Error: Invalid Free (object not live)
   Execution trace:
-      out.bpl(215,3): b#inputs
-  out.bpl(258,5): Error: a precondition for this call could not be proved
-  out.bpl(147,3): Related location: this is the precondition that could not be proved
+      out.bpl(226,3): b#inputs
+  Memory Error: Invalid Free (not base address)
   Execution trace:
-      out.bpl(252,3): b#inputs
-  out.bpl(258,5): Error: a precondition for this call could not be proved
-  out.bpl(148,3): Related location: this is the precondition that could not be proved
+      out.bpl(271,3): b#inputs
+  Memory Error: Invalid Free (object not live)
   Execution trace:
-      out.bpl(252,3): b#inputs
-  out.bpl(258,5): Error: a precondition for this call could not be proved
+      out.bpl(271,3): b#inputs
+  out.bpl(277,5): Error: a precondition for this call could not be proved
   out.bpl(146,3): Related location: this is the precondition that could not be proved
   Execution trace:
-      out.bpl(252,3): b#inputs
-  out.bpl(298,5): Error: this assertion could not be proved
+      out.bpl(271,3): b#inputs
+  Memory Error: Invalid Access
   Execution trace:
-      out.bpl(287,3): b#inputs
-  out.bpl(335,5): Error: this assertion could not be proved
+      out.bpl(306,3): b#inputs
+  Memory Error: Invalid Access
   Execution trace:
-      out.bpl(328,3): b#inputs
-  out.bpl(385,5): Error: a postcondition could not be proved on this return path
-  out.bpl(350,3): Related location: this is the postcondition that could not be proved
+      out.bpl(355,3): b#inputs
+  Memory Error: Memory Leak
   Execution trace:
-      out.bpl(368,3): b#inputs
+      out.bpl(403,3): b#inputs
   
   Boogie program verifier finished with 1 verified, 7 errors


### PR DESCRIPTION
The flat memory encoding has made its way to bincaml after enough procrastination. It even works under the same spec as the split encoding, yay!

Seems to all work well (I'm surprised by how little debugging i had to do actually). The test cases all pass except for one failure to verify in interproc, but that seems like a  whole ordeal and I'm quite happy with half of it verifying. 

I'm a little worried I did something bad to the submodules repo when rebasing accidentally?  but it seems to be working fine. Git is just giving me a scary "submodule exmaples deleted form 8a8cd5" change 💀 