### PR TITLE
Fix some broken passes

### DIFF
--- a/lib/analysis/linear_const.ml
+++ b/lib/analysis/linear_const.ml
@@ -73,9 +73,9 @@ module LF = struct
       inverses [mod 2^n].
 
       This computes the join of [ax + b] and [cx + d]. According to the paper we
-      can compute this as [(ax + b) join (a * l + b)], where [l = (b-d)/(c-a)], and
-      we can compute this only when [c-a] has an inverse [mod 2^n], i.e. only
-      when [c-a] is odd (as hence it is coprime to 2^n). *)
+      can compute this as [(ax + b) join (a * l + b)], where [l = (b-d)/(c-a)],
+      and we can compute this only when [c-a] has an inverse [mod 2^n], i.e.
+      only when [c-a] is odd (as hence it is coprime to 2^n). *)
   let compute_join a b c d =
     let bd = Bitvec.value (Bitvec.sub b d) in
     let ca = Bitvec.value (Bitvec.sub c a) in

--- a/lib/analysis/linear_const.ml
+++ b/lib/analysis/linear_const.ml
@@ -69,12 +69,14 @@ module LF = struct
     assert (canonical f);
     match f with IdEdge -> true | _ -> false
 
-  (* Definitions from https://doi.org/10.1016/0304-3975(96)00072-2 computing inverses mod 2^n *)
+  (** Definitions from {:https://doi.org/10.1016/0304-3975(96)00072-2} computing
+      inverses [mod 2^n].
 
+      This computes the join of [ax + b] and [cx + d]. According to the paper we
+      can compute this as [(ax + b) join (a * l + b)], where [l = (b-d)/(c-a)], and
+      we can compute this only when [c-a] has an inverse [mod 2^n], i.e. only
+      when [c-a] is odd (as hence it is coprime to 2^n). *)
   let compute_join a b c d =
-    (* This computes the join of ax + b and cx + d
-       According to the paper we can compute this as ax + b join a * l + b, where l = (b-d)/(c-a),
-       and we can compute this only when c-a has an inverse mod 2^n, i.e. only when c-a is odd (as hence it is coprime to 2^n) *)
     let bd = Bitvec.value (Bitvec.sub b d) in
     let ca = Bitvec.value (Bitvec.sub c a) in
     let pow = Z.pow (Z.of_int 2) (Bitvec.size a) in

--- a/lib/analysis/linear_const.ml
+++ b/lib/analysis/linear_const.ml
@@ -69,13 +69,15 @@ module LF = struct
     assert (canonical f);
     match f with IdEdge -> true | _ -> false
 
-  (* Definitions from https://doi.org/10.1016/0304-3975(96)00072-2 with gcdext modifications coming from computing inverses mod 2^n *)
+  (* Definitions from https://doi.org/10.1016/0304-3975(96)00072-2 computing inverses mod 2^n *)
 
   let compute_join a b c d =
     let bd = Bitvec.value (Bitvec.sub b d) in
-    let g, s, t = Z.gcdext (Bitvec.value (Bitvec.sub c a)) bd in
-    if Z.divisible g bd then
-      let l0 = Bitvec.create ~size:(Bitvec.size a) (Z.mul s bd) in
+    let ca = Bitvec.value (Bitvec.sub c a) in
+    let pow = Z.pow (Z.of_int 2) (Bitvec.size a) in
+    if Z.congruent ca Z.one pow then
+      let cainv = Z.invert ca pow in
+      let l0 = Bitvec.create ~size:(Bitvec.size a) (Z.mul cainv bd) in
       let j = Bitvec.add (Bitvec.mul a l0) b in
       Some (Value.V j)
     else None
@@ -95,6 +97,8 @@ module LF = struct
     match c with
     | Value.Top -> TopEdge
     | Bot -> make_linear a b
+    | Value.V c when Z.equal Z.zero (Bitvec.value a) && Bitvec.equal b c ->
+        Linear (a, b)
     | _ -> Join (a, b, c)
 
   (* Should make join edges with top become TopEdges (and probably similar for effectively id Linear and Join edges...) *)

--- a/lib/analysis/linear_const.ml
+++ b/lib/analysis/linear_const.ml
@@ -72,10 +72,13 @@ module LF = struct
   (* Definitions from https://doi.org/10.1016/0304-3975(96)00072-2 computing inverses mod 2^n *)
 
   let compute_join a b c d =
+    (* This computes the join of ax + b and cx + d
+       According to the paper we can compute this as ax + b join a * l + b, where l = (b-d)/(c-a),
+       and we can compute this only when c-a has an inverse mod 2^n, i.e. only when c-a is odd (as hence it is coprime to 2^n) *)
     let bd = Bitvec.value (Bitvec.sub b d) in
     let ca = Bitvec.value (Bitvec.sub c a) in
     let pow = Z.pow (Z.of_int 2) (Bitvec.size a) in
-    if Z.congruent ca Z.one pow then
+    if Z.is_odd ca then
       let cainv = Z.invert ca pow in
       let l0 = Bitvec.create ~size:(Bitvec.size a) (Z.mul cainv bd) in
       let j = Bitvec.add (Bitvec.mul a l0) b in

--- a/lib/invariants.ml
+++ b/lib/invariants.ml
@@ -38,7 +38,7 @@ open struct
   (** Unions the two invariant lists. *)
   let ( +++ ) a b : t list =
     let a = List.sort compare a and b = List.sort compare b in
-    List.sorted_merge ~cmp:compare a b
+    List.sorted_merge_uniq ~cmp:compare a b
 
   (** Subtracts the second invariant list from the first. *)
   let ( --- ) a b : t list =

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -322,7 +322,7 @@ module PassManager = struct
       doc =
         "Remove store assignments to pure local variables which are never read \
          using an interprocedural analysis";
-      invariants = Invariants.needs [ NoPhis ];
+      invariants = Invariants.needs [ SSA ];
     }
 
   let linear_const =

--- a/test/cram/inter_dead.sexp
+++ b/test/cram/inter_dead.sexp
@@ -1,6 +1,6 @@
 (load-il "inter_dead.il")
 (dump-il "before.il")
-(run-transform "inter-dead-store-elim")
+(run-transform "ssa" "inter-dead-store-elim")
 (dump-il "inter.il")
 
 (load-il "inter_dead.il")

--- a/test/cram/inter_dead.t
+++ b/test/cram/inter_dead.t
@@ -2,7 +2,7 @@
   $ bincaml script inter_dead.sexp
   (load-il inter_dead.il)
   (dump-il before.il)
-  (run-transform inter-dead-store-elim)
+  (run-transform ssa inter-dead-store-elim)
   (dump-il inter.il)
   (load-il inter_dead.il)
   (run-transform intra-dead-store-elim)
@@ -81,60 +81,91 @@
   prog entry @main;
 
   $ cat inter.il
-  var $global:bv64;
-  proc @main(inp:bv64)  -> () {  }
-    captures $global:bv64
+  proc @main(global_in:bv64, inp:bv64)  -> () {  }
+    
   
   [
+     block %inputs [ var global_1:bv64 := global_in:bv64; goto (%main_entry); ];
      block %main_entry [
-       var a:bv64 := inp:bv64;
-       (var a:bv64=out) := call @fun1(c=a:bv64);
-       (var x:bv64=out) := call @fun1(c=a:bv64);
-       assert eq(x:bv64, bvadd(a:bv64, a:bv64));
+       var a_1:bv64 := inp:bv64;
+       (var a_2:bv64=out) := call @fun1(c=a_1:bv64, global_in=global_1:bv64);
+       (var x_1:bv64=out) := call @fun1(c=a_2:bv64, global_in=global_1:bv64);
+       (var a_3:bv64 := a_2:bv64, var x_2:bv64 := x_1:bv64);
+       assert eq(x_2:bv64, bvadd(a_3:bv64, a_3:bv64));
        return;
      ]
   ];
-  proc @fun1(c:bv64)  -> (out:bv64) {  }
-    captures $global:bv64
+  proc @fun1(c:bv64, global_in:bv64)  -> (out:bv64) {  }
+    
   
   [
+     block %inputs [ var global_1:bv64 := global_in:bv64; goto (%fun1_entry); ];
      block %fun1_entry [
-       (var e:bv64=out2) := call @fun2();
-       var out:bv64 := bvadd(c:bv64, e:bv64);
+       (var e_1:bv64=out2) := call @fun2(global_in=global_1:bv64);
+       var out:bv64 := bvadd(c:bv64, e_1:bv64);
        return;
      ]
   ];
-  proc @fun2()  -> (out2:bv64) {  }
-    captures $global:bv64
+  proc @fun2(global_in:bv64)  -> (out2:bv64) {  }
+    
   
   [
+     block %inputs [ var global_1:bv64 := global_in:bv64; goto (%fun2_entry); ];
      block %fun2_entry [
-       var g:bv64 := $global;
-       var out2:bv64 := bvadd(g:bv64, g:bv64);
+       var g_1:bv64 := global_1:bv64;
+       var out2:bv64 := bvadd(g_1:bv64, g_1:bv64);
        return;
      ]
   ];
   prog entry @main;
 
   $ diff inter.il intra.il
-  7,9c7,9
-  <      var a:bv64 := inp:bv64;
-  <      (var a:bv64=out) := call @fun1(c=a:bv64);
-  <      (var x:bv64=out) := call @fun1(c=a:bv64);
+  1,2c1,3
+  < proc @main(global_in:bv64, inp:bv64)  -> () {  }
+  <   
+  ---
+  > var $global:bv64;
+  > proc @main(inp:bv64)  -> () {  }
+  >   captures $global:bv64
+  5d5
+  <    block %inputs [ var global_1:bv64 := global_in:bv64; goto (%main_entry); ];
+  7,11c7,10
+  <      var a_1:bv64 := inp:bv64;
+  <      (var a_2:bv64=out) := call @fun1(c=a_1:bv64, global_in=global_1:bv64);
+  <      (var x_1:bv64=out) := call @fun1(c=a_2:bv64, global_in=global_1:bv64);
+  <      (var a_3:bv64 := a_2:bv64, var x_2:bv64 := x_1:bv64);
+  <      assert eq(x_2:bv64, bvadd(a_3:bv64, a_3:bv64));
   ---
   >      (var a:bv64 := inp:bv64, var b:bv64 := inp:bv64);
   >      (var a:bv64=out) := call @fun1(c=a:bv64, d=b:bv64);
   >      (var x:bv64=out) := call @fun1(c=a:bv64, d=b:bv64);
-  14c14
-  < proc @fun1(c:bv64)  -> (out:bv64) {  }
+  >      assert eq(x:bv64, bvadd(a:bv64, a:bv64));
+  15,16c14,15
+  < proc @fun1(c:bv64, global_in:bv64)  -> (out:bv64) {  }
+  <   
   ---
   > proc @fun1(c:bv64, d:bv64)  -> (out:bv64) {  }
-  19c19
-  <      (var e:bv64=out2) := call @fun2();
+  >   captures $global:bv64
+  19d17
+  <    block %inputs [ var global_1:bv64 := global_in:bv64; goto (%fun1_entry); ];
+  21,22c19,20
+  <      (var e_1:bv64=out2) := call @fun2(global_in=global_1:bv64);
+  <      var out:bv64 := bvadd(c:bv64, e_1:bv64);
   ---
   >      (var e:bv64=out2) := call @fun2(f=d:bv64);
-  24c24
-  < proc @fun2()  -> (out2:bv64) {  }
+  >      var out:bv64 := bvadd(c:bv64, e:bv64);
+  26,27c24,25
+  < proc @fun2(global_in:bv64)  -> (out2:bv64) {  }
+  <   
   ---
   > proc @fun2(f:bv64)  -> (out2:bv64) {  }
+  >   captures $global:bv64
+  30d27
+  <    block %inputs [ var global_1:bv64 := global_in:bv64; goto (%fun2_entry); ];
+  32,33c29,30
+  <      var g_1:bv64 := global_1:bv64;
+  <      var out2:bv64 := bvadd(g_1:bv64, g_1:bv64);
+  ---
+  >      var g:bv64 := $global;
+  >      var out2:bv64 := bvadd(g:bv64, g:bv64);
   [1]


### PR DESCRIPTION
the simplify batch transform had multiple ssa requirements so this fixes that.

the linear const pass had an incorrect inverse computation, and hence an incorrect join leading to an infinite loop

interprocedural dead store elimination is now annotated as needing ssa (it uses the ssa ide solver)