### PR TITLE
Bind load/store funcs to global (not local) variables

### DIFF
--- a/lib/transforms/boogie_prepass.ml
+++ b/lib/transforms/boogie_prepass.ml
@@ -309,7 +309,7 @@ module Instructions = struct
              {
                attrib = attribs;
                binding =
-                 Var.create
+                 Var.create ~scope:Var.GlobalConst
                    (Printf.sprintf "store%d_%s" size
                       (Lang.Stmt.show_endian endian))
                    (Lang.Expr.BasilExpr.type_of value);
@@ -335,7 +335,7 @@ module Instructions = struct
              {
                attrib = attribs;
                binding =
-                 Var.create
+                 Var.create ~scope:Var.GlobalConst
                    (Printf.sprintf "load%d_%s" size (Stmt.show_endian endian))
                    (Var.typ lhs);
                definition = Function body;
@@ -422,7 +422,8 @@ module Normalise = struct
               [
                 ( lhs,
                   Expr.BasilExpr.fapply
-                    (Expr.BasilExpr.rvar (Var.create fn_name (Var.typ lhs)))
+                    (Expr.BasilExpr.rvar
+                       (Var.create ~scope:Var.GlobalConst fn_name (Var.typ lhs)))
                     [ Expr.BasilExpr.rvar rhs; addr ] );
               ];
             attrib;
@@ -438,7 +439,8 @@ module Normalise = struct
               [
                 ( lhs,
                   Expr.BasilExpr.fapply
-                    (Expr.BasilExpr.rvar (Var.create fn_name (Var.typ lhs)))
+                    (Expr.BasilExpr.rvar
+                       (Var.create ~scope:Var.GlobalConst fn_name (Var.typ lhs)))
                     [ Expr.BasilExpr.rvar rhs; addr; value ] );
               ];
             attrib;


### PR DESCRIPTION
The prepass for the Boogie backend replaces load/store statements with calls to functions encoding load/store logic. These functions are currently bound to *local* variables, even though they have top-level definitions. In comparison, the functions for BV builtins (which I assume should be treated equivalently) are bound to *global* variables.

In the expression simplification part of the prepass, local variables are assumed to refer to local lambdas, not top-level functions. Currently, the fact that load/store functions are bound to local variables does not cause issues because expression simplification is called before the load/store reduction. However, I suspect it would cause issues if the logic were reordered.

This PR updates the load/store functions to be bound to (and referenced through) global variables.