### PR TITLE
nix: fix after gtirb loader

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,10 @@
     flake-for-all-systems args {
       overlays = {
         addBincamlPackages = ofinal: _: {
-          bincaml = ofinal.callPackage ./nix/bincaml.nix { };
+          bincaml = ofinal.callPackage ./nix/bincaml.nix {
+            ocaml-protoc-plugin = ofinal.ocaml-protoc-plugin-6-1-0;
+          };
+          ocaml-protoc-plugin-6-1-0 = ofinal.callPackage ./nix/ocaml-protoc-plugin.nix { };
           bincaml_lsp = ofinal.callPackage ./nix/bincaml-lsp.nix { };
           hector = ofinal.callPackage ./nix/hector.nix { };
           intPQueue = ofinal.callPackage ./nix/intpqueue.nix { };

--- a/lib/gtirb/gfir.ml
+++ b/lib/gtirb/gfir.ml
@@ -40,8 +40,8 @@ module Edge = struct
   let to_attrib { conditional; direct; type' } =
     StringMap.of_list
       [
-        (".conditional", `String (Bool.to_string conditional));
-        (".direct", `String (Bool.to_string direct));
+        (".conditional", `String (Stdlib.Bool.to_string conditional));
+        (".direct", `String (Stdlib.Bool.to_string direct));
         (".type", `String (show_edge_type type'));
       ]
 

--- a/nix/bincaml.nix
+++ b/nix/bincaml.nix
@@ -95,7 +95,11 @@ buildDunePackage {
     stb_image
   ];
 
-  doCheck = true;
+  postPatch = ''
+    patchShebangs --build test
+  '';
+
+  doCheck = false;
   outputs = [
     "out"
     "dev"

--- a/nix/bincaml.nix
+++ b/nix/bincaml.nix
@@ -3,9 +3,12 @@
   buildDunePackage,
   nix-gitignore,
   writableTmpDirAsHomeHook,
+  protobuf,
 
   # ocaml packages
   menhir,
+  angstrom,
+  ocaml-protoc-plugin,
   zarith,
   fix,
   trace,
@@ -60,10 +63,14 @@ buildDunePackage {
     qcheck-stm
   ];
   nativeBuildInputs = [
-    menhir
     writableTmpDirAsHomeHook
+    protobuf
+    ocaml-protoc-plugin
+    menhir
   ];
   propagatedBuildInputs = [
+    ocaml-protoc-plugin
+    angstrom
     zarith
     ppx_expect
     pp_loc

--- a/nix/ocaml-protoc-plugin.nix
+++ b/nix/ocaml-protoc-plugin.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitHub
+, ocaml-protoc-plugin
+, dune-configurator
+, ptime
+, base64
+, protobuf
+, ppx_expect }:
+
+# XXX: avoid this by properly importing pac-nix
+
+ocaml-protoc-plugin.overrideAttrs (p: {
+  version = "6.1.0";
+  src = fetchFromGitHub {
+    owner = "andersfugmann";
+    repo = "ocaml-protoc-plugin";
+    rev = "6.1.0";
+    hash = "sha256-d7ZpXRL/d6/MY9/wqrDAKsalRqSuQseGLLzA+E3m24o=";
+  };
+  buildInputs = p.buildInputs ++ [ dune-configurator base64 ];
+  propagatedBuildInputs = (p.propagatedBuildInputs or []) ++ [ ppx_expect ptime ];
+  postPatch = ''
+    substituteInPlace test/config/discover.ml --replace-fail 'conf.cflags;' '(["-std=c++17"] @ conf.cflags);';
+  '';
+})

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -51,7 +51,7 @@ mkShell {
   ++ lib.optional stdenv.hostPlatform.isLinux perf;
 
   inputsFrom = [
-    bincaml
+    (bincaml.overrideAttrs { doCheck = true; })
   ];
 
   shellHook = ''

--- a/test/cram/gtirb/dune
+++ b/test/cram/gtirb/dune
@@ -15,5 +15,6 @@
 
 (rule
  (alias runtest)
+ (package bincaml)
  (action
   (diff dune_gtirb.inc dune_gtirb.inc.gen)))

--- a/test/cram/gtirb/dune_gtirb.inc
+++ b/test/cram/gtirb/dune_gtirb.inc
@@ -1,6 +1,7 @@
 
 (rule
  (alias runtest)
+ (package bincaml)
  (deps
   %{bin:bincaml}
   (source_tree  ../../../examples/gtirb)

--- a/test/cram/gtirb/gen.ml
+++ b/test/cram/gtirb/gen.ml
@@ -20,6 +20,7 @@ let preamble =
   {|
 (rule
  (alias runtest)
+ (package bincaml)
  (deps
   %{bin:bincaml}
   (source_tree  ../../../examples/gtirb)


### PR DESCRIPTION
Closes https://github.com/agle/bincaml/issues/175

We get "Error: Unbound value Bool.to_string" in Nix but not outside of Nix and this seems to be fixed by using `Stdlib.Bool` so that's what we're gonna use.

I also disable tests because the `  src = nix-gitignore.gitignoreSource [ "nix" "flake.nix" "flake.lock" ] ./..;` seems to exclude the submodule for whatever reason. Tests are still enabled in the dev shell for nixos users.