### PR TITLE
Fixed width zarith bvops

### DIFF
--- a/lib/util/bitvec.ml
+++ b/lib/util/bitvec.ml
@@ -1,5 +1,4 @@
 open Containers
-module I = Fixed_width_arith
 
 (* workaround: ZArith library doesn't like zero-length extracts *)
 let checked_extract f v off len = if len > 0 then f v off len else Z.zero
@@ -81,7 +80,7 @@ let of_string i =
 let size_is_equal a b = assert (size a = size b) [@@inline always]
 
 let size_if_equal a b =
-  if size_is_equal a b then size a else failwith "bv binop widths differ"
+  if a.w = b.w then size a else failwith "bv binop widths differ"
 [@@inline always]
 
 let bind1 f a = create ~size:a.w (f ~size:a.w a.v) [@@inline always]
@@ -99,77 +98,76 @@ let map2 f a b =
 [@@inline always]
 
 (** sign negation *)
-let neg a = bind1 I.neg a
+let neg a = bind1 Fixed_width_arith.neg a
 
 (** addition *)
-let add a b = bind2 I.add a b
+let add a b = bind2 Fixed_width_arith.add a b
 
 (** multiplication *)
-let mul a b = bind2 I.mul a b
+let mul a b = bind2 Fixed_width_arith.mul a b
 
 (** subtraction *)
-let sub a b = bind2 I.sub a b
+let sub a b = bind2 Fixed_width_arith.sub a b
 
 (** bitwise not *)
-let bitnot a = bind1 I.bitnot a
+let bitnot a = bind1 Fixed_width_arith.bitnot a
 
 (** bitwise and *)
-let bitand a b = bind2 I.bitand a b
+let bitand a b = bind2 Fixed_width_arith.bitand a b
 
 (** bitwise or *)
-let bitor a b = bind2 I.bitor a b
+let bitor a b = bind2 Fixed_width_arith.bitor a b
 
 (** bitwise exclusive or *)
-let bitxor a b = bind2 I.bitxor a b
+let bitxor a b = bind2 Fixed_width_arith.bitxor a b
 
 (** unsigned division *)
-let udiv a b = bind2 I.udiv a b
+let udiv a b = bind2 Fixed_width_arith.udiv a b
 
 (** unsigned remainder *)
-let urem a b = bind2 I.urem a b
+let urem a b = bind2 Fixed_width_arith.urem a b
 
 (** signed division *)
-let sdiv a b = bind2 I.sdiv a b
+let sdiv a b = bind2 Fixed_width_arith.sdiv a b
 
 (** Remainder with result sign following the dividend (a) sign. *)
-let srem a b = bind2 I.srem a b
+let srem a b = bind2 Fixed_width_arith.srem a b
 
 (** Remainder with result sign following the divisor (b) sign. *)
-let smod a b = bind2 I.smod a b
+let smod a b = bind2 Fixed_width_arith.smod a b
 
 (** unsigned less-than*)
-let ult a b = map2 I.ult a b
+let ult a b = map2 Fixed_width_arith.ult a b
 
 (** unsigned greater-than*)
-let ugt a b = map2 I.ugt a b
+let ugt a b = map2 Fixed_width_arith.ugt a b
 
 (** unsigned less-than-equals*)
-let ule a b = map2 I.ule a b
+let ule a b = map2 Fixed_width_arith.ule a b
 
 (** unsigned greater-than-equals*)
-let uge a b = map2 I.uge a b
-
+let uge a b = map2 Fixed_width_arith.uge a b
 
 (** signed less-than *)
-let slt a b = map2 I.slt a b
+let slt a b = map2 Fixed_width_arith.slt a b
 
 (** signed greater-than *)
-let sgt a b = map2 I.sgt a b
+let sgt a b = map2 Fixed_width_arith.sgt a b
 
 (** signed less-than-equals *)
-let sle a b = map2 I.sle a b
+let sle a b = map2 Fixed_width_arith.sle a b
 
 (** signed greater-than-equals *)
-let sge a b = map2 I.sge a b
+let sge a b = map2 Fixed_width_arith.sge a b
 
 (** arithmetic shift right *)
-let ashr a b = bind2 I.ashr a b
+let ashr a b = bind2 Fixed_width_arith.ashr a b
 
 (** logical shift right *)
-let lshr a b = bind2 I.lshr a b
+let lshr a b = bind2 Fixed_width_arith.lshr a b
 
 (** shift left *)
-let shl a b = bind2 I.shl a b
+let shl a b = bind2 Fixed_width_arith.shl a b
 
 (** extend [extension] zeros in msb position *)
 let zero_extend ~(extension : int) b = create ~size:(b.w + extension) b.v

--- a/lib/util/bitvec.ml
+++ b/lib/util/bitvec.ml
@@ -81,7 +81,7 @@ let of_string i =
 let size_is_equal a b = assert (size a = size b) [@@inline always]
 
 let size_if_equal a b =
-  if size a = size b then size a else failwith "bv binop widths differ"
+  if size_is_equal a b then size a else failwith "bv binop widths differ"
 [@@inline always]
 
 let bind1 f a = create ~size:a.w (f ~size:a.w a.v) [@@inline always]

--- a/lib/util/bitvec.ml
+++ b/lib/util/bitvec.ml
@@ -1,4 +1,5 @@
 open Containers
+module I = Fixed_width_arith
 
 (* workaround: ZArith library doesn't like zero-length extracts *)
 let checked_extract f v off len = if len > 0 then f v off len else Z.zero
@@ -78,110 +79,82 @@ let of_string i =
   { w; v }
 
 let size_is_equal a b = assert (size a = size b) [@@inline always]
-let bind1 f a = create ~size:a.w (f a.v) [@@inline always]
-let bind1_signed f a = create ~size:a.w (f a.v) [@@inline always]
+
+let size_if_equal a b =
+  if size a = size b then size a else failwith "bv binop widths differ"
+[@@inline always]
+
+let bind1 f a = create ~size:a.w (f ~size:a.w a.v) [@@inline always]
+(*let bind1_signed f a = create ~size:a.w (f ~size:a.w a.v) [@@inline always]*)
 
 (* wrap bv operation *)
 let bind2 f a b =
-  size_is_equal a b;
-  create ~size:a.w (f a.v b.v)
+  let size = size_if_equal a b in
+  create ~size:a.w (f ~size a.v b.v)
 [@@inline always]
 
 (* wrap signed bv operation *)
-let bind2_signed f a b =
-  size_is_equal a b;
-  create ~size:a.w (f (to_signed_bigint a) (to_signed_bigint b))
-[@@inline always]
+(*let bind2_signed f a b =
+  let size = size_is_equal a b in
+  create ~size (f ~size (to_signed_bigint a) (to_signed_bigint b))
+[@@inline always]*)
 
 let map2 f a b =
-  size_is_equal a b;
-  f a.v b.v
+  let size = size_if_equal a b in
+  f ~size a.v b.v
 [@@inline always]
 
-let neg a = bind1_signed Z.neg a
-let add a b = bind2 Z.add a b
-let mul a b = bind2 Z.mul a b
-let sub a b = bind2 Z.sub a b
-let bitnot a = bind1 Z.lognot a
-let bitand a b = bind2 Z.logand a b
-let bitor a b = bind2 Z.logor a b
-let bitxor a b = bind2 Z.logxor a b
-let udiv a b = if is_zero b then ones ~size:a.w else bind2 Z.div a b
-let urem a b = if is_zero b then a else bind2 Z.rem a b
+(** sign negation *)
+let neg a = bind1 I.neg a
 
-(** Signed division.
+(** addition *)
+let add a b = bind2 I.add a b
 
-    From Z3: https://z3prover.github.io/api/html/group__capi.html
+(** multiplication *)
+let mul a b = bind2 I.mul a b
 
-    It is defined in the following way:
-    - The floor of t1/t2 if t2 is different from zero, and t1*t2 >= 0.
-    - The ceiling of t1/t2 if t2 is different from zero, and t1*t2 < 0. If t2 is
-      zero, then the result is undefined. *)
-let sdiv a b =
-  if a.w = 0 then a
-  else begin
-    assert (is_nonzero b);
-    bind2_signed Z.div a b
-  end
+(** subtraction *)
+let sub a b = bind2 I.sub a b
+
+(** bitwise not *)
+let bitnot a = bind1 I.bitnot a
+
+(** bitwise and *)
+let bitand a b = bind2 I.bitand a b
+
+(** bitwise or *)
+let bitor a b = bind2 I.bitor a b
+
+(** bitwise exclusive or *)
+let bitxor a b = bind2 I.bitxor a b
+
+(** unsigned division *)
+let udiv a b = bind2 I.udiv a b
+
+(** unsigned remainder *)
+let urem a b = bind2 I.urem a b
+
+(** signed division *)
+let sdiv a b = bind2 I.sdiv a b
 
 (** Remainder with result sign following the dividend (a) sign. *)
-let srem a b =
-  if a.w = 0 then a
-  else begin
-    assert (is_nonzero b);
-    bind2_signed Z.rem a b
-  end
+let srem a b = bind2 I.srem a b
 
 (** Remainder with result sign following the divisor (b) sign. *)
-let smod a b =
-  size_is_equal a b;
-  if a.w = 0 then a
-  else begin
-    assert (is_nonzero b);
-    let w = a.w and a, b = (to_signed_bigint a, to_signed_bigint b) in
-    let remainder = Z.rem a b and wanted_sign = Z.sign b in
-    match (Z.sign remainder, wanted_sign) with
-    | 1, -1 -> create ~size:w Z.(remainder - abs b)
-    | -1, 1 -> create ~size:w Z.(remainder + abs b)
-    | _ -> create ~size:w remainder
-  end
+let smod a b = bind2 I.smod a b
 
-let ult a b = map2 Z.lt a b
-let ugt a b = map2 Z.gt a b
-let ule a b = map2 Z.leq a b
-let uge a b = map2 Z.geq a b
-
-let map2_signed f a b =
-  size_is_equal a b;
-  f (to_signed_bigint a) (to_signed_bigint b)
-
-let slt a b = map2_signed Z.lt a b
-let sgt a b = map2_signed Z.gt a b
-let sle a b = map2_signed Z.leq a b
-let sge a b = map2_signed Z.geq a b
-
-let ashr a b =
-  (* guard avoids overflows in second int argument of shift: should always fit in int*)
-  if Z.gt b.v (Z.of_int a.w) then
-    if Z.testbit a.v (a.w - 1) then ones ~size:a.w else zero ~size:a.w
-  else create ~size:a.w @@ Z.shift_right (to_signed_bigint a) (Z.to_int b.v)
-
-let lshr a b =
-  (* guard avoids overflows in second int argument of shift: should always fit in int*)
-  if Z.gt b.v (Z.of_int a.w) then zero ~size:a.w
-  else
-    create ~size:a.w
-    @@ Z.shift_right_trunc (to_unsigned_bigint a) (Z.to_int b.v)
-
+let ult a b = map2 I.ult a b
+let ugt a b = map2 I.ugt a b
+let ule a b = map2 I.ule a b
+let uge a b = map2 I.uge a b
+let slt a b = map2 I.slt a b
+let sgt a b = map2 I.sgt a b
+let sle a b = map2 I.sle a b
+let sge a b = map2 I.sge a b
+let ashr a b = bind2 I.ashr a b
+let lshr a b = bind2 I.lshr a b
+let shl a b = bind2 I.shl a b
 let zero_extend ~(extension : int) b = create ~size:(b.w + extension) b.v
-
-let sign_extend ~(extension : int) b =
-  create ~size:(b.w + extension) @@ to_signed_bigint b
-
-let shl a b =
-  (* shift left by a very large number will OOM. guard against that. *)
-  if Z.(geq b.v (of_int a.w)) then create ~size:a.w Z.zero
-  else create ~size:a.w @@ Z.shift_left (to_unsigned_bigint a) (Z.to_int b.v)
 
 let concat a b =
   let wd = a.w + b.w in
@@ -192,3 +165,6 @@ let concat a b =
 
 let repeat_bits ~(copies : int) a =
   List.init copies (fun _ -> a) |> List.fold_left concat empty
+
+let sign_extend ~(extension : int) b =
+  create ~size:(b.w + extension) @@ to_signed_bigint b

--- a/lib/util/bitvec.ml
+++ b/lib/util/bitvec.ml
@@ -93,12 +93,6 @@ let bind2 f a b =
   create ~size:a.w (f ~size a.v b.v)
 [@@inline always]
 
-(* wrap signed bv operation *)
-(*let bind2_signed f a b =
-  let size = size_is_equal a b in
-  create ~size (f ~size (to_signed_bigint a) (to_signed_bigint b))
-[@@inline always]*)
-
 let map2 f a b =
   let size = size_if_equal a b in
   f ~size a.v b.v
@@ -143,19 +137,44 @@ let srem a b = bind2 I.srem a b
 (** Remainder with result sign following the divisor (b) sign. *)
 let smod a b = bind2 I.smod a b
 
+(** unsigned less-than*)
 let ult a b = map2 I.ult a b
+
+(** unsigned greater-than*)
 let ugt a b = map2 I.ugt a b
+
+(** unsigned less-than-equals*)
 let ule a b = map2 I.ule a b
+
+(** unsigned greater-than-equals*)
 let uge a b = map2 I.uge a b
+
+
+(** signed less-than *)
 let slt a b = map2 I.slt a b
+
+(** signed greater-than *)
 let sgt a b = map2 I.sgt a b
+
+(** signed less-than-equals *)
 let sle a b = map2 I.sle a b
+
+(** signed greater-than-equals *)
 let sge a b = map2 I.sge a b
+
+(** arithmetic shift right *)
 let ashr a b = bind2 I.ashr a b
+
+(** logical shift right *)
 let lshr a b = bind2 I.lshr a b
+
+(** shift left *)
 let shl a b = bind2 I.shl a b
+
+(** extend [extension] zeros in msb position *)
 let zero_extend ~(extension : int) b = create ~size:(b.w + extension) b.v
 
+(** bitconcat *)
 let concat a b =
   let wd = a.w + b.w in
   let a = zero_extend ~extension:(wd - a.w) a in
@@ -163,8 +182,10 @@ let concat a b =
   let b = zero_extend ~extension:(wd - b.w) b in
   bitor a b
 
+(* bitconcat a with itself n times *)
 let repeat_bits ~(copies : int) a =
   List.init copies (fun _ -> a) |> List.fold_left concat empty
 
+(* extend sign bit by [extension] bits *)
 let sign_extend ~(extension : int) b =
   create ~size:(b.w + extension) @@ to_signed_bigint b

--- a/lib/util/dune
+++ b/lib/util/dune
@@ -3,6 +3,7 @@
  (name bincaml_util)
  (modules
   worklist
+  fixed_width_arith
   mtypes
   common
   unicode

--- a/lib/util/fixed_width_arith.ml
+++ b/lib/util/fixed_width_arith.ml
@@ -1,0 +1,162 @@
+open Containers
+
+(** Fixed-width bitvector operations on strictly positive arbitrary width Z.t
+    integers *)
+
+(* workaround: ZArith library doesn't like zero-length extracts *)
+let checked_extract f v off len = if len > 0 then f v off len else Z.zero
+let z_extract = checked_extract Z.extract
+let z_signed_extract = checked_extract Z.signed_extract
+
+(** Representation of bitvector with non-negative Z.t and an explicit size. *)
+
+let show b = Printf.sprintf "0x%s" (Z.format "%x" @@ b)
+let to_string v = show v
+let pp fmt b = Format.pp_print_string fmt (show b)
+let hash b = Z.hash b
+let ones ~(size : int) = z_extract Z.minus_one 0 size
+let zero = Z.zero
+let empty = zero
+let is_zero b = Z.equal Z.zero b
+let is_nonzero b = not (is_zero b)
+let to_signed_bigint ~size b = z_signed_extract b 0 size
+let to_unsigned_bigint ~size b = z_extract b 0 size
+let is_negative ~size b = Z.lt (to_signed_bigint ~size b) Z.zero
+let equal a b = Z.equal a b
+let true_bv = ones ~size:1
+let false_bv = zero
+let max_value_unsigned size = ones ~size
+
+(** [to_bytes v] converts a byte-aligned-width bitvector value to bytes with the
+    length matching [length v]*)
+let to_bytes ~size v =
+  assert (size mod 8 = 0);
+  assert (size / 8 > 0);
+  let bs = Bytes.init (size / 8) (fun _ -> Char.unsafe_chr 0) in
+  let bits = Z.to_bits v in
+  let len = min (String.length bits) (size / 8) in
+  if len > 0 then Bytes.blit_string bits 0 bs 0 len;
+  bs
+
+(** Extracts a slice of the given bitvector. The slice is extracted from [lo]
+    (inclusive) up to [hi] (exclusive). *)
+let extract ~hi ~lo (b : Z.t) =
+  assert (0 <= lo);
+  assert (lo <= hi);
+  z_extract b lo (hi - lo)
+
+let compare a b = Z.compare a b
+
+(** Smart constructor for {!t}. Extracts its bits from the two's complement
+    representation of the given {!Z.t}, with negative numbers being treated as
+    having an infinite number of [1]s to their left. *)
+let create ~(size : int) (v : Z.t) : Z.t =
+  assert (size >= 0);
+  z_extract v 0 size
+
+let of_int ~(size : int) i = create ~size (Z.of_int i)
+let of_bool i = create ~size:1 (if i then Z.one else Z.zero)
+let one ~(size : int) = create ~size Z.one
+let bind1 ~size f a = create ~size (f a) [@@inline always]
+let bind1_signed ~size f a = create ~size (f a) [@@inline always]
+
+(* wrap bv operation *)
+let bind2 ~size f a b = create ~size (f a b) [@@inline always]
+
+(* wrap signed bv operation *)
+let bind2_signed ~size f (a : Z.t) (b : Z.t) =
+  create ~size (f (to_signed_bigint ~size a) (to_signed_bigint ~size b))
+[@@inline always]
+
+let map2 f a b = f a b [@@inline always]
+let neg ~size a = bind1_signed ~size Z.neg a
+let add ~size a b = bind2 ~size Z.add a b
+let mul ~size a b = bind2 ~size Z.mul a b
+let sub ~size a b = bind2 ~size Z.sub a b
+let bitnot ~size a = bind1 ~size Z.lognot a
+let bitand ~size a b = bind2 ~size Z.logand a b
+let bitor ~size a b = bind2 ~size Z.logor a b
+let bitxor ~size a b = bind2 ~size Z.logxor a b
+let udiv ~size a b = if is_zero b then ones ~size else bind2 ~size Z.div a b
+let urem ~size a b = if is_zero b then a else bind2 ~size Z.rem a b
+
+(** Signed division.
+
+    From Z3: https://z3prover.github.io/api/html/group__capi.html
+
+    It is defined in the following way:
+    - The floor of t1/t2 if t2 is different from zero, and t1*t2 >= 0.
+    - The ceiling of t1/t2 if t2 is different from zero, and t1*t2 < 0. If t2 is
+      zero, then the result is undefined. *)
+let sdiv ~size (a : Z.t) b =
+  if size = 0 then a
+  else begin
+    assert (is_nonzero b);
+    bind2_signed ~size Z.div a b
+  end
+
+(** Remainder with result sign following the dividend (a) sign. *)
+let srem ~size a b =
+  if size = 0 then a
+  else begin
+    assert (is_nonzero b);
+    bind2_signed ~size Z.rem a b
+  end
+
+(** Remainder with result sign following the divisor (b) sign. *)
+let smod ~size a b =
+  if size = 0 then a
+  else begin
+    assert (is_nonzero b);
+    let w = size
+    and a, b = (to_signed_bigint ~size a, to_signed_bigint ~size b) in
+    let remainder = Z.rem a b and wanted_sign = Z.sign b in
+    match (Z.sign remainder, wanted_sign) with
+    | 1, -1 -> create ~size:w Z.(remainder - abs b)
+    | -1, 1 -> create ~size:w Z.(remainder + abs b)
+    | _ -> create ~size:w remainder
+  end
+
+let ult ~size a b = map2 Z.lt a b
+let ugt ~size a b = map2 Z.gt a b
+let ule ~size a b = map2 Z.leq a b
+let uge ~size a b = map2 Z.geq a b
+let truthy a = not @@ Z.equal Z.zero a
+
+let map2_signed ~size f a b =
+  f (to_signed_bigint ~size a) (to_signed_bigint ~size b)
+
+let slt ~size a b = map2_signed ~size Z.lt a b
+let sgt ~size a b = map2_signed ~size Z.gt a b
+let sle ~size a b = map2_signed ~size Z.leq a b
+let sge ~size a b = map2_signed ~size Z.geq a b
+
+let ashr ~size a b =
+  (* guard avoids overflows in second int argument of shift: should always fit in int*)
+  if Z.gt b (Z.of_int size) then
+    if Z.testbit a (size - 1) then ones ~size else zero
+  else create ~size @@ Z.shift_right (to_signed_bigint ~size a) (Z.to_int b)
+
+let lshr ~size a b =
+  (* guard avoids overflows in second int argument of shift: should always fit in int*)
+  if Z.gt b (Z.of_int size) then zero
+  else
+    create ~size
+    @@ Z.shift_right_trunc (to_unsigned_bigint ~size a) (Z.to_int b)
+
+let sign_extend ~(extension : int) ~size b =
+  create ~size:(size + extension) @@ to_signed_bigint ~size b
+
+let shl ~(size : int) a b =
+  (* shift left by a very large number will OOM. guard against that. *)
+  if Z.geq b (Z.of_int size) then zero
+  else create ~size @@ Z.shift_left (to_unsigned_bigint ~size a) (Z.to_int b)
+
+let concat ~size_a ~size_b a b =
+  let wd = size_a + size_b in
+  let a = shl ~size:wd a (of_int ~size:size_a size_b) in
+  bitor ~size:wd a b
+
+let repeat_bits ~size ~(copies : int) a =
+  List.init copies (fun _ -> a)
+  |> List.fold_left (concat ~size_a:size ~size_b:size) empty


### PR DESCRIPTION
Factor out fixed width arith encoding from the bitvector representation.