### PR TITLE
Aslp lifter can lift two opcodes now

### DIFF
--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -467,9 +467,16 @@ end
 
 let ensure_aslp_globals_exist prog = 9
 
-let a () =
-  let bincaml_aslp_state = ref Aslp_state.empty_lifter_state in
-  let module I = Bincaml_IBI (struct
-    let bincaml_lifter_state = bincaml_aslp_state
-  end) in
-  OfflineASL_pc.Offline.f_A64_decoder (module I) (Bitvec.zero ~size:32)
+let lift_opcode
+    (module I : OfflineASL_pc.Instruction_building_interface.IBI
+      with type bitvector = Bitvec.t
+       and type ast = Aslp_state.aslp_state) ~address opcode =
+  I.reset_ir ();
+  OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
+  I.get_ir ()
+
+let lift_code_block ~address opcodes =
+  let opcodes_and_addresses =
+    opcodes |> List.mapi (fun i op -> (op, (i * 4) + address))
+  in
+  ()

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -51,6 +51,8 @@ module Aslp_state : sig
   (** {1 Manipulation functions} *)
 
   val add_goto : aslp_state -> source:string -> target:string -> aslp_state
+  val add_stmt_to_block : aslp_state -> string -> stmt -> aslp_state
+  val add_stmt_to_active : lifter_state -> stmt -> lifter_state
   val append_aslp_states : aslp_state -> aslp_state -> aslp_state
 
   (** {1 Formatters} *)
@@ -109,11 +111,25 @@ end = struct
     and exit = f exit in
     { blocks; entry; exit }
 
+  let add_stmt_to_block state key stmt =
+    let blocks =
+      StringMap.update key
+        (function
+          | Some blk -> Some { blk with stmts = blk.stmts @ [ stmt ] }
+          | None -> failwith "add_stmt: block not found")
+        state.blocks
+    in
+    { state with blocks }
+
+  let add_stmt_to_active { active; state } stmt =
+    let state = add_stmt_to_block state active stmt in
+    { active; state }
+
   let add_goto aslp_state ~source ~target =
     let blocks =
       StringMap.update source
         (function
-          | Some k -> Some { k with succs = target :: k.succs }
+          | Some blk -> Some { blk with succs = target :: blk.succs }
           | _ -> failwith "add_goto: block not found")
         aslp_state.blocks
     in
@@ -142,6 +158,10 @@ struct
   type branch = string
   type ast = Aslp_state.aslp_state
 
+  let bincaml_emit stmt =
+    S.bincaml_lifter_state :=
+      Aslp_state.add_stmt_to_active !S.bincaml_lifter_state stmt
+
   let reset_ir =
    fun () -> S.bincaml_lifter_state := Aslp_state.empty_lifter_state
 
@@ -152,12 +172,15 @@ struct
   let bigint_add : bigint -> bigint -> bigint = Z.add
   let bigint_sub : bigint -> bigint -> bigint = Z.sub
   let bigint_mul : bigint -> bigint -> bigint = Z.mul
-  let undefined : unit -> expr = fun _ -> failwith ""
+  let undefined : unit -> expr = fun _ -> Expr.BasilExpr.bv_of_int ~size:0 0
 
   let mkBits : bigint -> bigint -> bitvector =
    fun size x -> Bitvec.create ~size:(Z.to_int size) x
 
-  let from_bitsLit : string -> bitvector = Bitvec.of_string
+  let from_bitsLit : string -> bitvector =
+   fun bitstring ->
+    Bitvec.of_string
+      (Printf.sprintf "0b%s:bv%d" bitstring (String.length bitstring))
 
   let frem_int : bigint -> bigint -> bigint =
    fun x y -> Z.sub x (Z.mul y (Z.fdiv x y))
@@ -178,7 +201,7 @@ struct
       bigint ->
       bitvector ->
       bitvector =
-   fun _ -> failwith ""
+   fun _ -> failwith "elem_set"
 
   let f_eq_bits : bigint -> bitvector -> bitvector -> bool =
    fun _ -> Bitvec.equal
@@ -255,15 +278,15 @@ struct
   let f_cvt_bits_uint : bigint -> bitvector -> bigint =
    fun _ -> Bitvec.to_unsigned_bigint
 
-  let f_sdiv_int : bigint -> bigint -> bigint = fun _ -> failwith ""
-  let f_shl_int : bigint -> bigint -> bigint = fun _ -> failwith ""
+  let f_sdiv_int : bigint -> bigint -> bigint = fun _ -> failwith "sdiv int"
+  let f_shl_int : bigint -> bigint -> bigint = fun _ -> failwith "shl int"
   let v_PSTATE_C : lexpr = Var.create "v_PSTATE_C" (Types.Bitvector 1)
   let v_PSTATE_Z : lexpr = Var.create "v_PSTATE_Z" (Types.Bitvector 1)
   let v_PSTATE_V : lexpr = Var.create "v_PSTATE_V" (Types.Bitvector 1)
   let v_PSTATE_N : lexpr = Var.create "v_PSTATE_N" (Types.Bitvector 1)
   let v__PC : lexpr = Var.create "v__PC" (Types.Bitvector 1)
-  let v__R : lexpr = Var.create "v__R" (Types.Bitvector 1)
-  let v__Z : lexpr = Var.create "v__Z" (Types.Bitvector 1)
+  let v__R : lexpr = Var.create "v__R" (Types.Bitvector 0)
+  let v__Z : lexpr = Var.create "v__Z" (Types.Bitvector 0)
   let v_SP_EL0 : lexpr = Var.create "v_SP_EL0" (Types.Bitvector 1)
   let v_FPSR : lexpr = Var.create "v_FPSR" (Types.Bitvector 1)
   let v_FPCR : lexpr = Var.create "v_FPCR" (Types.Bitvector 1)
@@ -288,181 +311,248 @@ struct
   let v___ExclusiveLocal : lexpr =
     Var.create "v___ExclusiveLocal" (Types.Bitvector 1)
 
-  let f_switch_context : branch -> unit = fun _ -> failwith ""
-  let f_gen_branch : expr -> branch * branch * branch = fun _ -> failwith ""
-  let f_true_branch : branch * branch * branch -> branch = fun _ -> failwith ""
-  let f_false_branch : branch * branch * branch -> branch = fun _ -> failwith ""
-  let f_merge_branch : branch * branch * branch -> branch = fun _ -> failwith ""
-  let f_gen_assert : expr -> unit = fun _ -> failwith ""
-  let f_gen_bit_lit : bigint -> bitvector -> expr = fun _ -> failwith ""
-  let f_gen_bool_lit : bool -> expr = fun _ -> failwith ""
-  let f_gen_int_lit : bigint -> expr = fun _ -> failwith ""
-  let f_decl_bv : string -> bigint -> lexpr = fun _ -> failwith ""
-  let f_decl_bool : string -> lexpr = fun _ -> failwith ""
-  let f_gen_load : lexpr -> expr = fun _ -> failwith ""
-  let f_gen_store : lexpr -> expr -> unit = fun _ -> failwith ""
-  let f_gen_array_load : lexpr -> bigint -> expr = fun _ -> failwith ""
-  let f_gen_array_store : lexpr -> bigint -> expr -> unit = fun _ -> failwith ""
+  let f_switch_context : branch -> unit = fun _ -> failwith "f_switch_context"
+
+  let f_gen_branch : expr -> branch * branch * branch =
+   fun _ -> failwith "f_gen_branch"
+
+  let f_true_branch : branch * branch * branch -> branch =
+   fun _ -> failwith "f_true_branch"
+
+  let f_false_branch : branch * branch * branch -> branch =
+   fun _ -> failwith "f_false_branch"
+
+  let f_merge_branch : branch * branch * branch -> branch =
+   fun _ -> failwith "f_merge_branch"
+
+  let f_gen_assert : expr -> unit = fun _ -> failwith "f_gen_assert"
+
+  let f_gen_bit_lit : bigint -> bitvector -> expr =
+   fun _ bv -> Expr.BasilExpr.const (`Bitvector bv)
+
+  let f_gen_bool_lit : bool -> expr = fun _ -> failwith "f_gen_bool_lit"
+  let f_gen_int_lit : bigint -> expr = fun _ -> failwith "f_gen_int_lit"
+
+  let f_decl_bv : string -> bigint -> lexpr =
+   fun name size -> Var.create name (Types.Bitvector (Z.to_int size))
+
+  let f_decl_bool : string -> lexpr = fun _ -> failwith "f_decl_bool"
+  let f_gen_load : lexpr -> expr = fun lhs -> Expr.BasilExpr.rvar lhs
+
+  let f_gen_store : lexpr -> expr -> unit =
+   fun lhs rhs ->
+    bincaml_emit
+      (Stmt.Instr_Assign { attrib = Attrib.empty; al = [ (lhs, rhs) ] })
+
+  let f_gen_array_load : lexpr -> bigint -> expr =
+   fun array idx ->
+    match Var.name array with
+    | "v__R" ->
+        f_gen_load (Var.create ("v__R" ^ Z.to_string idx) (Types.Bitvector 64))
+    | x -> failwith x
+
+  let f_gen_array_store : lexpr -> bigint -> expr -> unit =
+   fun array idx rhs ->
+    match Var.name array with
+    | "v__R" ->
+        f_gen_store
+          (Var.create ("v__R" ^ Z.to_string idx) (Types.Bitvector 64))
+          rhs
+    | x -> failwith x
 
   let f_gen_Elem_read : bigint -> bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_Elem_read"
 
   let f_gen_Elem_set : bigint -> bigint -> expr -> expr -> expr -> expr -> expr
       =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_Elem_set"
 
   (** [f_gen_Mem_set size address size acctype value] *)
   let f_gen_Mem_set : bigint -> expr -> expr -> expr -> expr -> unit =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_Mem_set"
 
   (** [f_gen_Mem_read size address size acctype value] *)
   let f_gen_Mem_read : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_Mem_read"
 
-  let f_AtomicStart : unit -> unit = fun _ -> failwith ""
-  let f_AtomicEnd : unit -> unit = fun _ -> failwith ""
+  let f_AtomicStart : unit -> unit = fun _ -> failwith "f_AtomicStart"
+  let f_AtomicEnd : unit -> unit = fun _ -> failwith "f_AtomicEnd"
 
   (** [f_gen_AArch64_MemTag_set address acctype value] *)
   let f_gen_AArch64_MemTag_set : expr -> expr -> expr -> unit =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_AArch64_MemTag_set"
 
   (** [f_gen_AArch64_MemTag_read address acctype] *)
-  let f_gen_AArch64_MemTag_read : expr -> expr -> expr = fun _ -> failwith ""
+  let f_gen_AArch64_MemTag_read : expr -> expr -> expr =
+   fun _ -> failwith "f_gen_AArch64_MemTag_read"
 
-  let f_gen_and_bool : expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_or_bool : expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_not_bool : expr -> expr = fun _ -> failwith ""
-  let f_gen_cvt_bits_uint : bigint -> expr -> expr = fun _ -> failwith ""
-  let f_gen_eq_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_ne_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_not_bits : bigint -> expr -> expr = fun _ -> failwith ""
-  let f_gen_cvt_bool_bv : expr -> expr = fun _ -> failwith ""
-  let f_gen_or_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_eor_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_and_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_add_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_sub_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_sdiv_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_sle_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_slt_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_mul_bits : bigint -> expr -> expr -> expr = fun _ -> failwith ""
+  let f_gen_and_bool : expr -> expr -> expr = fun _ -> failwith "f_gen_and_bool"
+  let f_gen_or_bool : expr -> expr -> expr = fun _ -> failwith "f_gen_or_bool"
+  let f_gen_not_bool : expr -> expr = fun _ -> failwith "f_gen_not_bool"
+
+  let f_gen_cvt_bits_uint : bigint -> expr -> expr =
+   fun _ -> failwith "f_gen_cvt_bits_uint"
+
+  let f_gen_eq_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_eq_bits"
+
+  let f_gen_ne_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_ne_bits"
+
+  let f_gen_not_bits : bigint -> expr -> expr =
+   fun _ -> failwith "f_gen_not_bits"
+
+  let f_gen_cvt_bool_bv : expr -> expr = fun _ -> failwith "f_gen_cvt_bool_bv"
+
+  let f_gen_or_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_or_bits"
+
+  let f_gen_eor_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_eor_bits"
+
+  let f_gen_and_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_and_bits"
+
+  let f_gen_add_bits : bigint -> expr -> expr -> expr =
+   fun _ -> Expr.BasilExpr.binexp ?attrib:None ~op:`BVADD
+
+  let f_gen_sub_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_sub_bits"
+
+  let f_gen_sdiv_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_sdiv_bits"
+
+  let f_gen_sle_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_sle_bits"
+
+  let f_gen_slt_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_slt_bits"
+
+  let f_gen_mul_bits : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_mul_bits"
 
   let f_gen_append_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_append_bits"
 
   let f_gen_lsr_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_lsr_bits"
 
   let f_gen_lsl_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ _ -> Expr.BasilExpr.binexp ?attrib:None ~op:`BVSHL
 
   let f_gen_asr_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_asr_bits"
 
   (** [f_gen_replicate_bits operand_width num_replications operand
        num_replications] *)
   let f_gen_replicate_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_replicate_bits"
 
   (** [f_gen_ZeroExtend operand_width result_width operand result_width] *)
   let f_gen_ZeroExtend : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_ZeroExtend"
 
   (** [f_gen_SignExtend operand_width result_width operand result_width] *)
   let f_gen_SignExtend : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_SignExtend"
 
-  let f_gen_slice : expr -> bigint -> bigint -> expr = fun _ -> failwith ""
+  let f_gen_slice : expr -> bigint -> bigint -> expr =
+   fun _ -> failwith "f_gen_slice"
 
   (* {1 Floating point intrinsics} *)
 
   let f_gen_FPCompare : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPCompare"
 
   let f_gen_FPCompareEQ : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPCompareEQ"
 
   let f_gen_FPCompareGE : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPCompareGE"
 
   let f_gen_FPCompareGT : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPCompareGT"
 
   let f_gen_FPAdd : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPAdd"
 
   let f_gen_FPSub : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPSub"
 
   let f_gen_FPMulAdd : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMulAdd"
 
   let f_gen_FPMulAddH : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMulAddH"
 
   let f_gen_FPMulX : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMulX"
 
   let f_gen_FPMul : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMul"
 
   let f_gen_FPDiv : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPDiv"
 
   let f_gen_FPMin : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMin"
 
   let f_gen_FPMinNum : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMinNum"
 
   let f_gen_FPMax : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMax"
 
   let f_gen_FPMaxNum : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPMaxNum"
 
-  let f_gen_FPRecpX : bigint -> expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_FPSqrt : bigint -> expr -> expr -> expr = fun _ -> failwith ""
+  let f_gen_FPRecpX : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_FPRecpX"
+
+  let f_gen_FPSqrt : bigint -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_FPSqrt"
 
   let f_gen_FPRecipEstimate : bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPRecipEstimate"
 
   let f_gen_UnsignedRSqrtEstimate : bigint -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_UnsignedRSqrtEstimate"
 
   let f_gen_FPRSqrtEstimate : bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPRSqrtEstimate"
 
-  let f_gen_BFAdd : expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_BFMul : expr -> expr -> expr = fun _ -> failwith ""
-  let f_gen_FPConvertBF : expr -> expr -> expr -> expr = fun _ -> failwith ""
+  let f_gen_BFAdd : expr -> expr -> expr = fun _ -> failwith "f_gen_BFAdd"
+  let f_gen_BFMul : expr -> expr -> expr = fun _ -> failwith "f_gen_BFMul"
+
+  let f_gen_FPConvertBF : expr -> expr -> expr -> expr =
+   fun _ -> failwith "f_gen_FPConvertBF"
 
   let f_gen_FPRecipStepFused : bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPRecipStepFused"
 
   let f_gen_FPRSqrtStepFused : bigint -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPRSqrtStepFused"
 
   let f_gen_FPToFixed :
       bigint -> bigint -> expr -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPToFixed"
 
   let f_gen_FixedToFP :
       bigint -> bigint -> expr -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FixedToFP"
 
   let f_gen_FPConvert : bigint -> bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPConvert"
 
   let f_gen_FPRoundInt : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPRoundInt"
 
   let f_gen_FPRoundIntN : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPRoundIntN"
 
   let f_gen_FPToFixedJS_impl : bigint -> bigint -> expr -> expr -> expr -> expr
       =
-   fun _ -> failwith ""
+   fun _ -> failwith "f_gen_FPToFixedJS_impl"
 end
 
 let ensure_aslp_globals_exist prog = 9

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -142,21 +142,31 @@ struct
   type branch = string
   type ast = Aslp_state.aslp_state
 
-  let reset_ir : unit -> unit = fun _ -> failwith ""
-  let get_ir : unit -> ast = fun _ -> failwith ""
-  let bigint_of_string : string -> bigint = fun _ -> failwith ""
-  let bigint_of_int : int -> bigint = fun _ -> failwith ""
+  let reset_ir =
+   fun () -> S.bincaml_lifter_state := Aslp_state.empty_lifter_state
+
+  let get_ir = fun () -> !S.bincaml_lifter_state.state
+  let bigint_of_string : string -> bigint = Z.of_string_base 10
+  let bigint_of_int : int -> bigint = Z.of_int
   let bigint_zero : bigint = Z.zero
-  let bigint_add : bigint -> bigint -> bigint = fun _ -> failwith ""
-  let bigint_sub : bigint -> bigint -> bigint = fun _ -> failwith ""
-  let bigint_mul : bigint -> bigint -> bigint = fun _ -> failwith ""
+  let bigint_add : bigint -> bigint -> bigint = Z.add
+  let bigint_sub : bigint -> bigint -> bigint = Z.sub
+  let bigint_mul : bigint -> bigint -> bigint = Z.mul
   let undefined : unit -> expr = fun _ -> failwith ""
-  let mkBits : bigint -> bigint -> bitvector = fun _ -> failwith ""
-  let from_bitsLit : string -> bitvector = fun _ -> failwith ""
-  let frem_int : bigint -> bigint -> bigint = fun _ -> failwith ""
+
+  let mkBits : bigint -> bigint -> bitvector =
+   fun size x -> Bitvec.create ~size:(Z.to_int size) x
+
+  let from_bitsLit : string -> bitvector = Bitvec.of_string
+
+  let frem_int : bigint -> bigint -> bigint =
+   fun x y -> Z.sub x (Z.mul y (Z.fdiv x y))
 
   let extract_bits : bitvector -> bigint -> bigint -> bitvector =
-   fun _ -> failwith ""
+   fun x lo wd ->
+    let wd = Z.to_int wd and lo = Z.to_int lo in
+    let hi = lo + wd in
+    Bitvec.extract ~lo ~hi x (* [hi] is exclusive *)
 
   (** [f_Elem_set operand_width elem_width operand elem_index elem_width elem]
   *)
@@ -171,71 +181,79 @@ struct
    fun _ -> failwith ""
 
   let f_eq_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.equal
 
   let f_ne_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ -> failwith ""
+   fun _ a b -> not (Bitvec.equal a b)
 
   let f_add_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.add
 
   let f_sub_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.sub
 
   let f_mul_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.mul
 
   let f_and_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.bitand
 
   let f_or_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.bitor
 
   let f_eor_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.bitxor
 
-  let f_not_bits : bigint -> bitvector -> bitvector = fun _ -> failwith ""
+  let f_not_bits : bigint -> bitvector -> bitvector = fun _ -> Bitvec.bitnot
 
   let f_slt_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.slt
 
   let f_sle_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ -> failwith ""
+   fun _ -> Bitvec.sle
 
-  let f_zeros_bits : bigint -> bitvector = fun _ -> failwith ""
-  let f_ones_bits : bigint -> bitvector = fun _ -> failwith ""
+  let f_zeros_bits : bigint -> bitvector =
+   fun size -> Bitvec.zero ~size:(Z.to_int size)
+
+  let f_ones_bits : bigint -> bitvector =
+   fun size -> Bitvec.ones ~size:(Z.to_int size)
 
   (** [f_replicate_bits operand_width num_replications operand num_replications]
   *)
   let f_replicate_bits : bigint -> bigint -> bitvector -> bigint -> bitvector =
-   fun _ -> failwith ""
+   fun _ _ x copies -> Bitvec.repeat_bits ~copies:(Z.to_int copies) x
 
   (** [f_append_bits w1 w2 x1 x2] *)
   let f_append_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ _ -> Bitvec.concat
 
   (** [f_ZeroExtend operand_width result_width operand result_width] *)
   let f_ZeroExtend : bigint -> bigint -> bitvector -> bigint -> bitvector =
-   fun _ -> failwith ""
+   fun wd result_wd x _ ->
+    let extension = Z.(to_int (result_wd - wd)) in
+    Bitvec.zero_extend ~extension x
 
   (** [f_SignExtend operand_width result_width operand result_width] *)
   let f_SignExtend : bigint -> bigint -> bitvector -> bigint -> bitvector =
-   fun _ -> failwith ""
+   fun wd result_wd x _ ->
+    let extension = Z.(to_int (result_wd - wd)) in
+    Bitvec.sign_extend ~extension x
 
   (** [f_lsl_bits operand_width shift_width operand shift] *)
   let f_lsl_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ _ -> Bitvec.shl
 
   (** [f_lsr_bits operand_width shift_width operand shift] *)
   let f_lsr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ _ -> Bitvec.lshr
 
   (** [f_asr_bits operand_width shift_width operand shift] *)
   let f_asr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> failwith ""
+   fun _ _ -> Bitvec.ashr
 
   (** [f_cvt_bits_uint operand_width operand] *)
-  let f_cvt_bits_uint : bigint -> bitvector -> bigint = fun _ -> failwith ""
+  let f_cvt_bits_uint : bigint -> bitvector -> bigint =
+   fun _ -> Bitvec.to_unsigned_bigint
 
   let f_sdiv_int : bigint -> bigint -> bigint = fun _ -> failwith ""
   let f_shl_int : bigint -> bigint -> bigint = fun _ -> failwith ""
@@ -355,6 +373,8 @@ struct
    fun _ -> failwith ""
 
   let f_gen_slice : expr -> bigint -> bigint -> expr = fun _ -> failwith ""
+
+  (* {1 Floating point intrinsics} *)
 
   let f_gen_FPCompare : bigint -> expr -> expr -> expr -> expr -> expr =
    fun _ -> failwith ""

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -9,7 +9,7 @@ module Aslp_state : sig
 
   type aslp_block = {
     assume : Expr.BasilExpr.t option;
-    stmts : (Var.t, Var.t, Expr.BasilExpr.t) Stmt.t list;
+    stmts : (Var.t, Var.t, Expr.BasilExpr.t) Stmt.t CCVector.vector;
     succs : string list;
   }
   (** An ASLp lifter block is a list of statements followed by a
@@ -68,9 +68,12 @@ end = struct
     ((Var.t, Var.t, Expr.BasilExpr.t) Stmt.t[@printer Stmt.pp_stmt_basil])
   [@@deriving show]
 
+  type _stmt_list = stmt list [@@deriving show]
+
   type aslp_block = {
     assume : Expr.BasilExpr.t option;
-    stmts : stmt list;
+    stmts : stmt CCVector.vector;
+        [@printer Format.map CCVector.to_list pp__stmt_list]
     succs : string list;
   }
   [@@deriving show]
@@ -90,8 +93,9 @@ end = struct
     let blocks =
       StringMap.of_list
         [
-          (entry, { assume = None; stmts = []; succs = [ exit ] });
-          (exit, { assume = None; stmts = []; succs = [] });
+          ( entry,
+            { assume = None; stmts = CCVector.create (); succs = [ exit ] } );
+          (exit, { assume = None; stmts = CCVector.create (); succs = [] });
         ]
     in
     { blocks; entry; exit }
@@ -115,7 +119,9 @@ end = struct
     let blocks =
       StringMap.update key
         (function
-          | Some blk -> Some { blk with stmts = blk.stmts @ [ stmt ] }
+          | Some blk ->
+              CCVector.push blk.stmts stmt;
+              Some blk
           | None -> failwith "add_stmt: block not found")
         state.blocks
     in

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -4,6 +4,9 @@ open Common
 module Aslp_state : sig
   (** {1 Types} *)
 
+  type stmt = (Var.t, Var.t, Expr.BasilExpr.t) Stmt.t
+  (** A statement within the Bincaml AST. This is just a type alias. *)
+
   type aslp_block = {
     assume : Expr.BasilExpr.t option;
     stmts : (Var.t, Var.t, Expr.BasilExpr.t) Stmt.t list;
@@ -131,19 +134,19 @@ module Bincaml_IBI (S : sig
   val bincaml_lifter_state : Aslp_state.lifter_state ref
 end) =
 struct
-  type bigint = int
-  type bitvector = int
-  type expr = int
-  type lexpr = int
-  type stmt = int
-  type branch = int
-  type ast = int
+  type bigint = Z.t
+  type bitvector = Bitvec.t
+  type expr = Expr.BasilExpr.t
+  type lexpr = Var.t
+  type stmt = Aslp_state.stmt
+  type branch = string
+  type ast = Aslp_state.aslp_state
 
   let reset_ir : unit -> unit = fun _ -> failwith ""
   let get_ir : unit -> ast = fun _ -> failwith ""
   let bigint_of_string : string -> bigint = fun _ -> failwith ""
   let bigint_of_int : int -> bigint = fun _ -> failwith ""
-  let bigint_zero : bigint = 0
+  let bigint_zero : bigint = Z.zero
   let bigint_add : bigint -> bigint -> bigint = fun _ -> failwith ""
   let bigint_sub : bigint -> bigint -> bigint = fun _ -> failwith ""
   let bigint_mul : bigint -> bigint -> bigint = fun _ -> failwith ""
@@ -236,31 +239,37 @@ struct
 
   let f_sdiv_int : bigint -> bigint -> bigint = fun _ -> failwith ""
   let f_shl_int : bigint -> bigint -> bigint = fun _ -> failwith ""
-  let v_PSTATE_C : lexpr = 0
-  let v_PSTATE_Z : lexpr = 0
-  let v_PSTATE_V : lexpr = 0
-  let v_PSTATE_N : lexpr = 0
-  let v__PC : lexpr = 0
-  let v__R : lexpr = 0
-  let v__Z : lexpr = 0
-  let v_SP_EL0 : lexpr = 0
-  let v_FPSR : lexpr = 0
-  let v_FPCR : lexpr = 0
-  let v_PSTATE_A : lexpr = 0
-  let v_PSTATE_D : lexpr = 0
-  let v_PSTATE_DIT : lexpr = 0
-  let v_PSTATE_F : lexpr = 0
-  let v_PSTATE_I : lexpr = 0
-  let v_PSTATE_PAN : lexpr = 0
-  let v_PSTATE_SP : lexpr = 0
-  let v_PSTATE_SSBS : lexpr = 0
-  let v_PSTATE_TCO : lexpr = 0
-  let v_PSTATE_UAO : lexpr = 0
-  let v_PSTATE_BTYPE : lexpr = 0
-  let v_BTypeCompatible : lexpr = 0
-  let v___BranchTaken : lexpr = 0
-  let v_BTypeNext : lexpr = 0
-  let v___ExclusiveLocal : lexpr = 0
+  let v_PSTATE_C : lexpr = Var.create "v_PSTATE_C" (Types.Bitvector 1)
+  let v_PSTATE_Z : lexpr = Var.create "v_PSTATE_Z" (Types.Bitvector 1)
+  let v_PSTATE_V : lexpr = Var.create "v_PSTATE_V" (Types.Bitvector 1)
+  let v_PSTATE_N : lexpr = Var.create "v_PSTATE_N" (Types.Bitvector 1)
+  let v__PC : lexpr = Var.create "v__PC" (Types.Bitvector 1)
+  let v__R : lexpr = Var.create "v__R" (Types.Bitvector 1)
+  let v__Z : lexpr = Var.create "v__Z" (Types.Bitvector 1)
+  let v_SP_EL0 : lexpr = Var.create "v_SP_EL0" (Types.Bitvector 1)
+  let v_FPSR : lexpr = Var.create "v_FPSR" (Types.Bitvector 1)
+  let v_FPCR : lexpr = Var.create "v_FPCR" (Types.Bitvector 1)
+  let v_PSTATE_A : lexpr = Var.create "v_PSTATE_A" (Types.Bitvector 1)
+  let v_PSTATE_D : lexpr = Var.create "v_PSTATE_D" (Types.Bitvector 1)
+  let v_PSTATE_DIT : lexpr = Var.create "v_PSTATE_DIT" (Types.Bitvector 1)
+  let v_PSTATE_F : lexpr = Var.create "v_PSTATE_F" (Types.Bitvector 1)
+  let v_PSTATE_I : lexpr = Var.create "v_PSTATE_I" (Types.Bitvector 1)
+  let v_PSTATE_PAN : lexpr = Var.create "v_PSTATE_PAN" (Types.Bitvector 1)
+  let v_PSTATE_SP : lexpr = Var.create "v_PSTATE_SP" (Types.Bitvector 1)
+  let v_PSTATE_SSBS : lexpr = Var.create "v_PSTATE_SSBS" (Types.Bitvector 1)
+  let v_PSTATE_TCO : lexpr = Var.create "v_PSTATE_TCO" (Types.Bitvector 1)
+  let v_PSTATE_UAO : lexpr = Var.create "v_PSTATE_UAO" (Types.Bitvector 1)
+  let v_PSTATE_BTYPE : lexpr = Var.create "v_PSTATE_BTYPE" (Types.Bitvector 1)
+
+  let v_BTypeCompatible : lexpr =
+    Var.create "v_BTypeCompatible" (Types.Bitvector 1)
+
+  let v___BranchTaken : lexpr = Var.create "v___BranchTaken" (Types.Bitvector 1)
+  let v_BTypeNext : lexpr = Var.create "v_BTypeNext" (Types.Bitvector 1)
+
+  let v___ExclusiveLocal : lexpr =
+    Var.create "v___ExclusiveLocal" (Types.Bitvector 1)
+
   let f_switch_context : branch -> unit = fun _ -> failwith ""
   let f_gen_branch : expr -> branch * branch * branch = fun _ -> failwith ""
   let f_true_branch : branch * branch * branch -> branch = fun _ -> failwith ""
@@ -443,4 +452,4 @@ let a () =
   let module I = Bincaml_IBI (struct
     let bincaml_lifter_state = bincaml_aslp_state
   end) in
-  OfflineASL_pc.Offline.f_A64_decoder (module I) 2
+  OfflineASL_pc.Offline.f_A64_decoder (module I) (Bitvec.zero ~size:32)

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -43,9 +43,8 @@ module Aslp_state : sig
 
   (** {1 Base functions} *)
 
-  val empty_aslp_state : aslp_state
-  val empty_lifter_state : lifter_state
-  val map_aslp_block_names : (string -> string) -> aslp_block -> aslp_block
+  val empty_aslp_state : unit -> aslp_state
+  val empty_lifter_state : unit -> lifter_state
   val map_aslp_state_names : (string -> string) -> aslp_state -> aslp_state
 
   (** {1 Manipulation functions} *)
@@ -88,7 +87,7 @@ end = struct
 
   type lifter_state = { active : string; state : aslp_state } [@@deriving show]
 
-  let empty_aslp_state =
+  let empty_aslp_state () =
     let entry = "entry" and exit = "exit" in
     let blocks =
       StringMap.of_list
@@ -100,7 +99,7 @@ end = struct
     in
     { blocks; entry; exit }
 
-  let empty_lifter_state = { active = "entry"; state = empty_aslp_state }
+  let empty_lifter_state () = { active = "entry"; state = empty_aslp_state () }
 
   let map_aslp_block_names f { assume; stmts; succs } =
     let succs = List.map f succs in
@@ -109,7 +108,7 @@ end = struct
   let map_aslp_state_names f { blocks; entry; exit } =
     let blocks =
       blocks |> StringMap.to_iter
-      |> Iter.map (fun (k, v) -> (f k, v))
+      |> Iter.map (fun (k, v) -> (f k, map_aslp_block_names f v))
       |> StringMap.of_iter
     and entry = f entry
     and exit = f exit in
@@ -169,7 +168,7 @@ struct
       Aslp_state.add_stmt_to_active !S.bincaml_lifter_state stmt
 
   let reset_ir =
-   fun () -> S.bincaml_lifter_state := Aslp_state.empty_lifter_state
+   fun () -> S.bincaml_lifter_state := Aslp_state.empty_lifter_state ()
 
   let get_ir = fun () -> !S.bincaml_lifter_state.state
   let bigint_of_string : string -> bigint = Z.of_string_base 10
@@ -268,17 +267,22 @@ struct
     let extension = Z.(to_int (result_wd - wd)) in
     Bitvec.sign_extend ~extension x
 
+  let unify_shift_widths apply_shift operand shift =
+    let extension = Bitvec.(size operand - size shift) in
+    let shift = Bitvec.zero_extend ~extension shift in
+    apply_shift operand shift
+
   (** [f_lsl_bits operand_width shift_width operand shift] *)
   let f_lsl_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ _ -> Bitvec.shl
+   fun _ _ -> unify_shift_widths Bitvec.shl
 
   (** [f_lsr_bits operand_width shift_width operand shift] *)
   let f_lsr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ _ -> Bitvec.lshr
+   fun _ _ -> unify_shift_widths Bitvec.lshr
 
   (** [f_asr_bits operand_width shift_width operand shift] *)
   let f_asr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ _ -> Bitvec.ashr
+   fun _ _ -> unify_shift_widths Bitvec.ashr
 
   (** [f_cvt_bits_uint operand_width operand] *)
   let f_cvt_bits_uint : bigint -> bitvector -> bigint =
@@ -571,8 +575,18 @@ let lift_opcode
   OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
   I.get_ir ()
 
-let lift_code_block ~address opcodes =
-  let opcodes_and_addresses =
-    opcodes |> List.mapi (fun i op -> (op, (i * 4) + address))
-  in
-  ()
+let lift_code_block
+    (module I : OfflineASL_pc.Instruction_building_interface.IBI
+      with type bitvector = Bitvec.t
+       and type ast = Aslp_state.aslp_state) ~address opcodes =
+  Iter.foldi
+    (fun state_acc i op ->
+      let address = Bitvec.add (Bitvec.create ~size:64 Z.(~$4 * ~$i)) address in
+      let prefix = Int.to_string i ^ "_" in
+      let lifted =
+        lift_opcode (module I) ~address op
+        |> Aslp_state.map_aslp_state_names (fun s -> prefix ^ s)
+      in
+      Aslp_state.append_aslp_states state_acc lifted)
+    (Aslp_state.empty_aslp_state ())
+    opcodes

--- a/lib/util/bitvec.ml
+++ b/lib/util/bitvec.ml
@@ -80,7 +80,8 @@ let of_string i =
 let size_is_equal a b = assert (size a = size b) [@@inline always]
 
 let size_if_equal a b =
-  if a.w = b.w then size a else failwith "bv binop widths differ"
+  if a.w = b.w then size a
+  else failwith (Printf.sprintf "bv binop widths differ. a:%d, b:%d" a.w b.w)
 [@@inline always]
 
 let bind1 f a = create ~size:a.w (f ~size:a.w a.v) [@@inline always]

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -3,7 +3,7 @@ open Common
 open Transforms.Aslp
 
 let%expect_test "lift: add x1, x2, x3, lsl #4" =
-  let bincaml_aslp_state = ref Aslp_state.empty_lifter_state in
+  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
   let module I = Bincaml_IBI (struct
     let bincaml_lifter_state = bincaml_aslp_state
   end) in
@@ -28,7 +28,36 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
       entry = "entry"; exit = "exit" }
     |}]
 
-let%expect_test "aslp basic" =
+let%expect_test "lift 2x: mov x1, #0xabcd" =
+  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
+  let module I = Bincaml_IBI (struct
+    let bincaml_lifter_state = bincaml_aslp_state
+  end) in
+  let x =
+    lift_code_block (module I) ~address:(Bitvec.zero ~size:64)
+    @@ Iter.doubleton
+         (Bitvec.of_string "0xd29579a1:bv32")
+         (Bitvec.of_string "0xd29579a1:bv32")
+  in
+  print_endline @@ Aslp_state.show_aslp_state x;
+  [%expect
+    {|
+    { Aslp.Aslp_state.blocks = "0_entry"
+      -> { Aslp.Aslp_state.assume = None;
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_exit"] },
+      "0_exit"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_entry"] },
+      "1_entry"
+      -> { Aslp.Aslp_state.assume = None;
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_exit"] },
+      "1_exit" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
+      "entry" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["exit"] },
+      "exit"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_entry"] };
+      entry = "entry"; exit = "1_exit" }
+    |}]
+
+let%expect_test "aslp integration basic" =
   let lst =
     Loader.Loadir.ast_of_string
       {|

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -1,5 +1,31 @@
 open Lang
 open Common
+open Transforms.Aslp
+
+let%expect_test "lift one opcode" =
+  let bincaml_aslp_state = ref Aslp_state.empty_lifter_state in
+  let module I = Bincaml_IBI (struct
+    let bincaml_lifter_state = bincaml_aslp_state
+  end) in
+  let x =
+    lift_opcode
+      (module I)
+      ~address:(Bitvec.zero ~size:64)
+      (Bitvec.of_string "0x8b031041:bv32")
+  in
+  print_endline @@ Aslp_state.show_aslp_state x;
+  [%expect {|
+    { Aslp.Aslp_state.blocks = "entry"
+      -> { Aslp.Aslp_state.assume = None;
+           stmts =
+           [var X.read8__2:bv64 := v__R2:bv64;
+             var X.read14__3:bv64 := v__R3:bv64;
+             var v__R1:bv64 := bvadd(X.read8__2:bv64, bvshl(X.read14__3:bv64, 0x4:bv12))
+             ];
+           succs = ["exit"] },
+      "exit" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
+      entry = "entry"; exit = "exit" }
+    |}]
 
 let%expect_test "aslp basic" =
   let lst =

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -2,7 +2,7 @@ open Lang
 open Common
 open Transforms.Aslp
 
-let%expect_test "lift one opcode" =
+let%expect_test "lift: add x1, x2, x3, lsl #4" =
   let bincaml_aslp_state = ref Aslp_state.empty_lifter_state in
   let module I = Bincaml_IBI (struct
     let bincaml_lifter_state = bincaml_aslp_state
@@ -14,7 +14,8 @@ let%expect_test "lift one opcode" =
       (Bitvec.of_string "0x8b031041:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_state x;
-  [%expect {|
+  [%expect
+    {|
     { Aslp.Aslp_state.blocks = "entry"
       -> { Aslp.Aslp_state.assume = None;
            stmts =


### PR DESCRIPTION
It's easiest to see the outcome of this PR in the test changes (below). We can now lift a very simple opcode into the special block type. We can also join the result of lifting two opcodes into one big "block", which can later be converted into one or more Bincaml blocks.

This PR sets up a lot of the groundwork by defining the concrete types (variable, expression, etc) and also the functions which build up the partial evaluation result. It also changes the statement list to a CCVector which is a small optimisation. We will probably need to do someting about ASLp's variable names - they use `.` inside the name and this won't fly in bincaml.


The big remaining TODO is to draw the rest of the horse. 

```ocaml
let%expect_test "lift: add x1, x2, x3, lsl #4" =
  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
  let module I = Bincaml_IBI (struct
    let bincaml_lifter_state = bincaml_aslp_state
  end) in
  let x =
    lift_opcode
      (module I)
      ~address:(Bitvec.zero ~size:64)
      (Bitvec.of_string "0x8b031041:bv32")
  in
  print_endline @@ Aslp_state.show_aslp_state x;
  [%expect
    {|
    { Aslp.Aslp_state.blocks = "entry"
      -> { Aslp.Aslp_state.assume = None;
           stmts =
           [var X.read8__2:bv64 := v__R2:bv64;
             var X.read14__3:bv64 := v__R3:bv64;
             var v__R1:bv64 := bvadd(X.read8__2:bv64, bvshl(X.read14__3:bv64, 0x4:bv12))
             ];
           succs = ["exit"] },
      "exit" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
      entry = "entry"; exit = "exit" }
    |}]


let%expect_test "lift 2x: mov x1, #0xabcd" =
  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
  let module I = Bincaml_IBI (struct
    let bincaml_lifter_state = bincaml_aslp_state
  end) in
  let x =
    lift_code_block (module I) ~address:(Bitvec.zero ~size:64)
    @@ Iter.doubleton
         (Bitvec.of_string "0xd29579a1:bv32")
         (Bitvec.of_string "0xd29579a1:bv32")
  in
  print_endline @@ Aslp_state.show_aslp_state x;
  [%expect
    {|
    { Aslp.Aslp_state.blocks = "0_entry"
      -> { Aslp.Aslp_state.assume = None;
           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_exit"] },
      "0_exit"
      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_entry"] },
      "1_entry"
      -> { Aslp.Aslp_state.assume = None;
           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_exit"] },
      "1_exit" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
      "entry" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["exit"] },
      "exit"
      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_entry"] };
      entry = "entry"; exit = "1_exit" }
    |}]
```