### PR TITLE
Clean Aslp local var names and use `ID.generator`

### DIFF
--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -392,15 +392,13 @@ struct
   let v_PSTATE_BTYPE : lexpr = Var.create "v_PSTATE_BTYPE" (Types.Bitvector 1)
 
   let v_BTypeCompatible : lexpr =
-    bincaml_local_var "v_BTypeCompatible" (Types.Bitvector 1)
+    Var.create "v_BTypeCompatible" (Types.Bitvector 1)
 
-  let v___BranchTaken : lexpr =
-    bincaml_local_var "v___BranchTaken" (Types.Bitvector 1)
-
-  let v_BTypeNext : lexpr = bincaml_local_var "v_BTypeNext" (Types.Bitvector 1)
+  let v___BranchTaken : lexpr = Var.create "v___BranchTaken" (Types.Bitvector 1)
+  let v_BTypeNext : lexpr = Var.create "v_BTypeNext" (Types.Bitvector 1)
 
   let v___ExclusiveLocal : lexpr =
-    bincaml_local_var "v___ExclusiveLocal" (Types.Bitvector 1)
+    Var.create "v___ExclusiveLocal" (Types.Bitvector 1)
 
   let f_switch_context : branch -> unit = fun _ -> failwith "f_switch_context"
 

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -1,6 +1,37 @@
 open Lang
 open Common
 
+module Aslp_IDs = struct
+  type t = {
+    names : (string, int) Hashtbl.t;
+        (** Names and their associated unique ID. *)
+    count : int ref;
+        (** Count of unique IDs {i ever} emitted by this generator. Importantly,
+            this counts names which have been forgotten. *)
+  }
+
+  let create () = { names = Hashtbl.create 16; count = ref 0 }
+
+  (** Returns a fresh ID. *)
+  let fresh { names; count } =
+    let prev = !count in
+    count := prev + 1;
+    prev
+
+  (** Returns the ID associated with the given name, or creates and stores a new
+      ID if the name is not yet known. *)
+  let find name st =
+    match Hashtbl.find_opt st.names name with
+    | None ->
+        let n = fresh st in
+        Hashtbl.replace st.names name n;
+        n
+    | Some n -> n
+
+  (** Returns a copy of the {!t} which forgets all known name associations. *)
+  let forget st = { names = Hashtbl.copy st.names; count = ref !(st.count) }
+end
+
 module Aslp_state : sig
   (** {1 Types} *)
 
@@ -33,16 +64,13 @@ module Aslp_state : sig
       instructions. Or, it forms a part of {!lifter_state} for
       {i within}-instruction state. *)
 
-  type lifter_generators = {
-    block_ids : ID.generator;
-    local_ids : ID.generator;
-    num_locals : int ref;
-  }
+  type aslp_ids = { block_ids : Aslp_IDs.t; local_ids : Aslp_IDs.t }
+  (** Generators for unique IDs used by the offline lifter. *)
 
   type lifter_state = {
     active : string;
     state : aslp_state;
-    generator : lifter_generators;
+    generator : aslp_ids;
   }
   (** Intermediate offline lifter state while {i within} one particular
       instruction.
@@ -51,11 +79,11 @@ module Aslp_state : sig
       instruction. The offline IBI ({!Bincaml_IBI}) operates by mutating a
       reference to this state. *)
 
-  (** {1 Base functions} *)
+  (** {1 Utility functions} *)
 
   val empty_aslp_state : entry:string -> exit:string -> unit -> aslp_state
 
-  val empty_lifter_state : ?generator:lifter_generators -> unit -> lifter_state
+  val empty_lifter_state : ?generator:aslp_ids -> unit -> lifter_state
   (** Constructs a new empty {!lifter_state}.
 
       Callers should consider whether they wish to re-use an existing
@@ -63,7 +91,18 @@ module Aslp_state : sig
 
   val map_aslp_state_names : (string -> string) -> aslp_state -> aslp_state
 
-  (** {1 Manipulation functions} *)
+  (** {2 ID generating functions} *)
+
+  val initial_aslp_ids : unit -> aslp_ids
+  val gen_block_id : aslp_ids -> string
+  val gen_local_id : aslp_ids -> string -> string
+
+  (** Returns a copy of the given lifter ID generator, but with the local
+      {i names} forgotten. This means that existing local names will become
+      inaccessible, though the {!num_locals} count will remain to ensure that
+      their numbers are not re-used. *)
+
+  (** {1 State manipulation functions} *)
 
   val add_goto : aslp_state -> source:string -> target:string -> aslp_state
   val add_stmt_to_block : aslp_state -> string -> stmt -> aslp_state
@@ -101,20 +140,21 @@ end = struct
   }
   [@@deriving show]
 
-  type lifter_generators = {
-    block_ids : ID.generator;
-    local_ids : ID.generator;
-    num_locals : int ref;
-  }
+  type aslp_ids = { block_ids : Aslp_IDs.t; local_ids : Aslp_IDs.t }
 
-  let initial_lifter_generators () =
-    let num_locals = ref 0 in
-    { block_ids = ID.make_gen (); local_ids = ID.make_gen (); num_locals }
+  let initial_aslp_ids () =
+    { block_ids = Aslp_IDs.create (); local_ids = Aslp_IDs.create () }
+
+  let gen_block_id gens =
+    Printf.sprintf "block_%d" @@ Aslp_IDs.fresh gens.block_ids
+
+  let gen_local_id gens name =
+    Printf.sprintf "var_%d" @@ Aslp_IDs.find name gens.local_ids
 
   type lifter_state = {
     active : string;
     state : aslp_state;
-    generator : lifter_generators; [@opaque]
+    generator : aslp_ids; [@opaque]
   }
   [@@deriving show]
 
@@ -130,9 +170,9 @@ end = struct
     { blocks; entry; exit }
 
   let empty_lifter_state ?generator () =
-    let generator = Option.get_lazy initial_lifter_generators generator in
-    let entry = generator.block_ids.fresh ~name:"entry" () |> ID.name in
-    let exit = generator.block_ids.fresh ~name:"exit" () |> ID.name in
+    let generator = Option.get_lazy initial_aslp_ids generator in
+    let entry = gen_block_id generator in
+    let exit = gen_block_id generator in
     { active = entry; state = empty_aslp_state ~entry ~exit (); generator }
 
   let map_aslp_block_names f { assume; stmts; succs } =
@@ -200,6 +240,10 @@ struct
   let bincaml_emit stmt =
     S.bincaml_lifter_state :=
       Aslp_state.add_stmt_to_active !S.bincaml_lifter_state stmt
+
+  let bincaml_local_var name ty =
+    let name = Aslp_state.gen_local_id !S.bincaml_lifter_state.generator name in
+    Var.create name ty
 
   let reset_ir () =
     let generator = !S.bincaml_lifter_state.generator in
@@ -348,13 +392,15 @@ struct
   let v_PSTATE_BTYPE : lexpr = Var.create "v_PSTATE_BTYPE" (Types.Bitvector 1)
 
   let v_BTypeCompatible : lexpr =
-    Var.create "v_BTypeCompatible" (Types.Bitvector 1)
+    bincaml_local_var "v_BTypeCompatible" (Types.Bitvector 1)
 
-  let v___BranchTaken : lexpr = Var.create "v___BranchTaken" (Types.Bitvector 1)
-  let v_BTypeNext : lexpr = Var.create "v_BTypeNext" (Types.Bitvector 1)
+  let v___BranchTaken : lexpr =
+    bincaml_local_var "v___BranchTaken" (Types.Bitvector 1)
+
+  let v_BTypeNext : lexpr = bincaml_local_var "v_BTypeNext" (Types.Bitvector 1)
 
   let v___ExclusiveLocal : lexpr =
-    Var.create "v___ExclusiveLocal" (Types.Bitvector 1)
+    bincaml_local_var "v___ExclusiveLocal" (Types.Bitvector 1)
 
   let f_switch_context : branch -> unit = fun _ -> failwith "f_switch_context"
 
@@ -379,7 +425,7 @@ struct
   let f_gen_int_lit : bigint -> expr = fun _ -> failwith "f_gen_int_lit"
 
   let f_decl_bv : string -> bigint -> lexpr =
-   fun name size -> Var.create name (Types.Bitvector (Z.to_int size))
+   fun name size -> bincaml_local_var name (Types.Bitvector (Z.to_int size))
 
   let f_decl_bool : string -> lexpr = fun _ -> failwith "f_decl_bool"
   let f_gen_load : lexpr -> expr = fun lhs -> Expr.BasilExpr.rvar lhs

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -33,10 +33,7 @@ module Aslp_state : sig
       instructions. Or, it forms a part of {!lifter_state} for
       {i within}-instruction state. *)
 
-  type aslp_ids = {
-    block_ids : Fix.Gensym.generator;
-    local_ids : Fix.Gensym.generator;
-  }
+  type aslp_ids = { block_ids : unit -> int; local_ids : unit -> int }
   (** Generators for unique IDs used by the offline lifter.
 
       The {!aslp_ids} is stateful and the same {!aslp_ids} should be used by all
@@ -71,18 +68,24 @@ module Aslp_state : sig
       Callers should consider whether they wish to re-use an existing
       [generator] value by passing it explicitly. *)
 
-  val map_aslp_state_names : (string -> string) -> aslp_state -> aslp_state
+  val empty_aslp_ids : unit -> aslp_ids
+  (** Construct a new {!aslp_ids} with no pre-existing IDs.
+
+      Be careful! You should use {!aslp_ids_from_generators} if you will use the
+      lifted statements within an existing Bincaml IR. *)
 
   (** {2 ID generating functions} *)
 
-  val initial_aslp_ids : unit -> aslp_ids
+  val aslp_ids_from_generators :
+    block_ids:ID.generator -> local_ids:ID.generator -> aslp_ids
+  (** Construct a {!aslp_ids} with the given {!Bincaml_util.ID.generator}s as
+      underlying generators.
+
+      This will ensure that ASLp's local variable and block names do not clash
+      with existing names. *)
+
   val gen_block_id : aslp_ids -> string
   val gen_local_id : aslp_ids -> string
-
-  (** Returns a copy of the given lifter ID generator, but with the local
-      {i names} forgotten. This means that existing local names will become
-      inaccessible, though the {!num_locals} count will remain to ensure that
-      their numbers are not re-used. *)
 
   (** {1 State manipulation functions} *)
 
@@ -122,19 +125,18 @@ end = struct
   }
   [@@deriving show]
 
-  type aslp_ids = {
-    block_ids : Fix.Gensym.generator;
-    local_ids : Fix.Gensym.generator;
-  }
+  type aslp_ids = { block_ids : unit -> int; local_ids : unit -> int }
 
-  let initial_aslp_ids () =
-    { block_ids = Fix.Gensym.generator (); local_ids = Fix.Gensym.generator () }
+  let empty_aslp_ids () =
+    { block_ids = Fix.Gensym.make (); local_ids = Fix.Gensym.make () }
 
-  let gen_block_id gens =
-    Printf.sprintf "block_%d" @@ Fix.Gensym.fresh gens.block_ids
+  let aslp_ids_from_generators ~block_ids ~local_ids =
+    let block_ids = ID.index % ID.fresh block_ids in
+    let local_ids = ID.index % ID.fresh local_ids in
+    { block_ids; local_ids }
 
-  let gen_local_id gens =
-    Printf.sprintf "var_%d" @@ Fix.Gensym.fresh gens.local_ids
+  let gen_block_id gens = Printf.sprintf "block_%d" @@ gens.block_ids ()
+  let gen_local_id gens = Printf.sprintf "var_%d" @@ gens.local_ids ()
 
   type lifter_state = {
     active : string;
@@ -156,7 +158,7 @@ end = struct
     { blocks; entry; exit }
 
   let empty_lifter_state ?generator () =
-    let generator = Option.get_lazy initial_aslp_ids generator in
+    let generator = Option.get_lazy empty_aslp_ids generator in
     let entry = gen_block_id generator in
     let exit = gen_block_id generator in
     {
@@ -165,19 +167,6 @@ end = struct
       names = Hashtbl.create 16;
       generator;
     }
-
-  let map_aslp_block_names f { assume; stmts; succs } =
-    let succs = List.map f succs in
-    { assume; stmts; succs }
-
-  let map_aslp_state_names f { blocks; entry; exit } =
-    let blocks =
-      blocks |> StringMap.to_iter
-      |> Iter.map (fun (k, v) -> (f k, map_aslp_block_names f v))
-      |> StringMap.of_iter
-    and entry = f entry
-    and exit = f exit in
-    { blocks; entry; exit }
 
   let add_stmt_to_block state key stmt =
     let blocks =
@@ -644,21 +633,27 @@ struct
    fun _ -> failwith "f_gen_FPToFixedJS_impl"
 end
 
+module type Bincaml_IBI = sig
+  include
+    OfflineASL_pc.Instruction_building_interface.IBI
+      with type bitvector = Bitvec.t
+       and type ast = Aslp_state.aslp_state
+end
+
 let ensure_aslp_globals_exist prog = 9
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_opcode
-    (module I : OfflineASL_pc.Instruction_building_interface.IBI
-      with type bitvector = Bitvec.t
-       and type ast = Aslp_state.aslp_state) ~address opcode =
+let lift_opcode (module I : Bincaml_IBI) ~address opcode =
   Fun.protect ~finally:I.reset_ir (fun () ->
       OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
       I.get_ir ())
 
-let lift_code_block
-    (module I : OfflineASL_pc.Instruction_building_interface.IBI
-      with type bitvector = Bitvec.t
-       and type ast = Aslp_state.aslp_state) ~address opcodes =
+(** Requires and ensures that the IBI is in the "reset" state. *)
+let lift_empty (module I : Bincaml_IBI) () =
+  Fun.protect ~finally:I.reset_ir (fun () -> I.get_ir ())
+
+(** Requires and ensures that the IBI is in the "reset" state. *)
+let lift_code_block (module I : Bincaml_IBI) ~address opcodes =
   opcodes
   |> Iter.foldi
        (fun acc i op ->
@@ -670,5 +665,4 @@ let lift_code_block
          | None -> Some lifted
          | Some acc -> Some (Aslp_state.append_aslp_states acc lifted))
        None
-  |> Option.get_lazy (fun () ->
-      Aslp_state.empty_aslp_state ~entry:"A" ~exit:"B" ())
+  |> Option.get_lazy (lift_empty (module I))

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -65,14 +65,11 @@ module Aslp_state : sig
 
   val empty_aslp_state : entry:string -> exit:string -> unit -> aslp_state
 
-  val empty_lifter_state :
-    ?entry:string -> ?exit:string -> ?generator:aslp_ids -> unit -> lifter_state
+  val empty_lifter_state : ?generator:aslp_ids -> unit -> lifter_state
   (** Constructs a new empty {!lifter_state}.
 
       Callers should consider whether they wish to re-use an existing
-      [generator] value by passing it explicitly. [entry] and [exit] can also be
-      provided explicitly. If not provided, these will be generated using the
-      generator. *)
+      [generator] value by passing it explicitly. *)
 
   val map_aslp_state_names : (string -> string) -> aslp_state -> aslp_state
 
@@ -158,10 +155,10 @@ end = struct
     in
     { blocks; entry; exit }
 
-  let empty_lifter_state ?entry ?exit ?generator () =
+  let empty_lifter_state ?generator () =
     let generator = Option.get_lazy initial_aslp_ids generator in
-    let entry = Option.get_lazy (fun () -> gen_block_id generator) entry in
-    let exit = Option.get_lazy (fun () -> gen_block_id generator) exit in
+    let entry = gen_block_id generator in
+    let exit = gen_block_id generator in
     {
       active = entry;
       state = empty_aslp_state ~entry ~exit ();
@@ -649,28 +646,33 @@ end
 
 let ensure_aslp_globals_exist prog = 9
 
+(** Requires and ensures that the IBI is in the "reset" state. *)
 let lift_opcode
     (module I : OfflineASL_pc.Instruction_building_interface.IBI
       with type bitvector = Bitvec.t
        and type ast = Aslp_state.aslp_state) ~address opcode =
-  I.reset_ir ();
-  OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
-  I.get_ir ()
+  Fun.protect ~finally:I.reset_ir (fun () ->
+      OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
+      I.get_ir ())
 
 let lift_code_block
     (module I : OfflineASL_pc.Instruction_building_interface.IBI
       with type bitvector = Bitvec.t
        and type ast = Aslp_state.aslp_state) ~address opcodes =
-  let initial =
-    Aslp_state.empty_aslp_state ~entry:"entryyyy" ~exit:"exittt" ()
-  in
-  Iter.foldi
-    (fun state_acc i op ->
-      let address = Bitvec.add (Bitvec.create ~size:64 Z.(~$4 * ~$i)) address in
-      let prefix = Int.to_string i ^ "_" in
-      let lifted =
-        lift_opcode (module I) ~address op
-        |> Aslp_state.map_aslp_state_names (fun s -> prefix ^ s)
-      in
-      Aslp_state.append_aslp_states state_acc lifted)
-    initial opcodes
+  opcodes
+  |> Iter.foldi
+       (fun acc i op ->
+         let address =
+           Bitvec.add (Bitvec.create ~size:64 Z.(~$4 * ~$i)) address
+         in
+         let prefix = Int.to_string i ^ "_" in
+         let lifted =
+           lift_opcode (module I) ~address op
+           |> Aslp_state.map_aslp_state_names (fun s -> prefix ^ s)
+         in
+         match acc with
+         | None -> Some lifted
+         | Some acc -> Some (Aslp_state.append_aslp_states acc lifted))
+       None
+  |> Option.get_lazy (fun () ->
+      Aslp_state.empty_aslp_state ~entry:"A" ~exit:"B" ())

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -134,7 +134,7 @@ end = struct
     Printf.sprintf "block_%d" @@ Fix.Gensym.fresh gens.block_ids
 
   let gen_local_id gens =
-    Printf.sprintf "var_%d" @@ Fix.Gensym.fresh gens.block_ids
+    Printf.sprintf "var_%d" @@ Fix.Gensym.fresh gens.local_ids
 
   type lifter_state = {
     active : string;
@@ -665,11 +665,7 @@ let lift_code_block
          let address =
            Bitvec.add (Bitvec.create ~size:64 Z.(~$4 * ~$i)) address
          in
-         let prefix = Int.to_string i ^ "_" in
-         let lifted =
-           lift_opcode (module I) ~address op
-           |> Aslp_state.map_aslp_state_names (fun s -> prefix ^ s)
-         in
+         let lifted = lift_opcode (module I) ~address op in
          match acc with
          | None -> Some lifted
          | Some acc -> Some (Aslp_state.append_aslp_states acc lifted))

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -37,13 +37,22 @@ module Aslp_state : sig
     block_ids : Fix.Gensym.generator;
     local_ids : Fix.Gensym.generator;
   }
-  (** Generators for unique IDs used by the offline lifter. *)
+  (** Generators for unique IDs used by the offline lifter.
+
+      The {!aslp_ids} is stateful and the same {!aslp_ids} should be used by all
+      opcodes within the same procedure, to ensure that IDs are unique.*)
 
   type lifter_state = {
     active : string;
+        (** Active block where new runtime statements will be appended. *)
     state : aslp_state;
-    generator : aslp_ids;
+        (** Lifter state representing a control flow diamond. *)
+    generator : aslp_ids;  (** Generators for ID numbers. *)
     names : (string, string) Hashtbl.t;
+        (** Map of ASLp local variable names to the "ID-ified" names produced
+            for Bincaml.
+
+            Local variables names are scoped to each {i instruction}. *)
   }
   (** Intermediate offline lifter state while {i within} one particular
       instruction.
@@ -56,11 +65,14 @@ module Aslp_state : sig
 
   val empty_aslp_state : entry:string -> exit:string -> unit -> aslp_state
 
-  val empty_lifter_state : ?generator:aslp_ids -> unit -> lifter_state
+  val empty_lifter_state :
+    ?entry:string -> ?exit:string -> ?generator:aslp_ids -> unit -> lifter_state
   (** Constructs a new empty {!lifter_state}.
 
       Callers should consider whether they wish to re-use an existing
-      [generator] value by passing it explicitly. *)
+      [generator] value by passing it explicitly. [entry] and [exit] can also be
+      provided explicitly. If not provided, these will be generated using the
+      generator. *)
 
   val map_aslp_state_names : (string -> string) -> aslp_state -> aslp_state
 
@@ -146,10 +158,10 @@ end = struct
     in
     { blocks; entry; exit }
 
-  let empty_lifter_state ?generator () =
+  let empty_lifter_state ?entry ?exit ?generator () =
     let generator = Option.get_lazy initial_aslp_ids generator in
-    let entry = gen_block_id generator in
-    let exit = gen_block_id generator in
+    let entry = Option.get_lazy (fun () -> gen_block_id generator) entry in
+    let exit = Option.get_lazy (fun () -> gen_block_id generator) exit in
     {
       active = entry;
       state = empty_aslp_state ~entry ~exit ();
@@ -182,7 +194,7 @@ end = struct
     in
     { state with blocks }
 
-  let add_stmt_to_active lifter_state stmt =
+  let add_stmt_to_active (lifter_state : lifter_state) stmt =
     let state = add_stmt_to_block lifter_state.state lifter_state.active stmt in
     { lifter_state with state }
 
@@ -240,7 +252,7 @@ struct
     let generator = !S.bincaml_lifter_state.generator in
     S.bincaml_lifter_state := Aslp_state.empty_lifter_state ~generator ()
 
-  let get_ir = fun () -> !S.bincaml_lifter_state.state
+  let get_ir () = !S.bincaml_lifter_state.state
   let bigint_of_string : string -> bigint = Z.of_string_base 10
   let bigint_of_int : int -> bigint = Z.of_int
   let bigint_zero : bigint = Z.zero

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -33,7 +33,17 @@ module Aslp_state : sig
       instructions. Or, it forms a part of {!lifter_state} for
       {i within}-instruction state. *)
 
-  type lifter_state = { active : string; state : aslp_state }
+  type lifter_generators = {
+    block_ids : ID.generator;
+    local_ids : ID.generator;
+    num_locals : int ref;
+  }
+
+  type lifter_state = {
+    active : string;
+    state : aslp_state;
+    generator : lifter_generators;
+  }
   (** Intermediate offline lifter state while {i within} one particular
       instruction.
 
@@ -43,8 +53,14 @@ module Aslp_state : sig
 
   (** {1 Base functions} *)
 
-  val empty_aslp_state : unit -> aslp_state
-  val empty_lifter_state : unit -> lifter_state
+  val empty_aslp_state : entry:string -> exit:string -> unit -> aslp_state
+
+  val empty_lifter_state : ?generator:lifter_generators -> unit -> lifter_state
+  (** Constructs a new empty {!lifter_state}.
+
+      Callers should consider whether they wish to re-use an existing
+      [generator] value by passing it explicitly. *)
+
   val map_aslp_state_names : (string -> string) -> aslp_state -> aslp_state
 
   (** {1 Manipulation functions} *)
@@ -85,10 +101,24 @@ end = struct
   }
   [@@deriving show]
 
-  type lifter_state = { active : string; state : aslp_state } [@@deriving show]
+  type lifter_generators = {
+    block_ids : ID.generator;
+    local_ids : ID.generator;
+    num_locals : int ref;
+  }
 
-  let empty_aslp_state () =
-    let entry = "entry" and exit = "exit" in
+  let initial_lifter_generators () =
+    let num_locals = ref 0 in
+    { block_ids = ID.make_gen (); local_ids = ID.make_gen (); num_locals }
+
+  type lifter_state = {
+    active : string;
+    state : aslp_state;
+    generator : lifter_generators; [@opaque]
+  }
+  [@@deriving show]
+
+  let empty_aslp_state ~entry ~exit () =
     let blocks =
       StringMap.of_list
         [
@@ -99,7 +129,11 @@ end = struct
     in
     { blocks; entry; exit }
 
-  let empty_lifter_state () = { active = "entry"; state = empty_aslp_state () }
+  let empty_lifter_state ?generator () =
+    let generator = Option.get_lazy initial_lifter_generators generator in
+    let entry = generator.block_ids.fresh ~name:"entry" () |> ID.name in
+    let exit = generator.block_ids.fresh ~name:"exit" () |> ID.name in
+    { active = entry; state = empty_aslp_state ~entry ~exit (); generator }
 
   let map_aslp_block_names f { assume; stmts; succs } =
     let succs = List.map f succs in
@@ -126,9 +160,9 @@ end = struct
     in
     { state with blocks }
 
-  let add_stmt_to_active { active; state } stmt =
+  let add_stmt_to_active { active; state; generator } stmt =
     let state = add_stmt_to_block state active stmt in
-    { active; state }
+    { active; state; generator }
 
   let add_goto aslp_state ~source ~target =
     let blocks =
@@ -167,8 +201,9 @@ struct
     S.bincaml_lifter_state :=
       Aslp_state.add_stmt_to_active !S.bincaml_lifter_state stmt
 
-  let reset_ir =
-   fun () -> S.bincaml_lifter_state := Aslp_state.empty_lifter_state ()
+  let reset_ir () =
+    let generator = !S.bincaml_lifter_state.generator in
+    S.bincaml_lifter_state := Aslp_state.empty_lifter_state ~generator ()
 
   let get_ir = fun () -> !S.bincaml_lifter_state.state
   let bigint_of_string : string -> bigint = Z.of_string_base 10
@@ -579,6 +614,9 @@ let lift_code_block
     (module I : OfflineASL_pc.Instruction_building_interface.IBI
       with type bitvector = Bitvec.t
        and type ast = Aslp_state.aslp_state) ~address opcodes =
+  let initial =
+    Aslp_state.empty_aslp_state ~entry:"entryyyy" ~exit:"exittt" ()
+  in
   Iter.foldi
     (fun state_acc i op ->
       let address = Bitvec.add (Bitvec.create ~size:64 Z.(~$4 * ~$i)) address in
@@ -588,5 +626,4 @@ let lift_code_block
         |> Aslp_state.map_aslp_state_names (fun s -> prefix ^ s)
       in
       Aslp_state.append_aslp_states state_acc lifted)
-    (Aslp_state.empty_aslp_state ())
-    opcodes
+    initial opcodes

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -62,7 +62,7 @@ module Aslp_state : sig
 
   val empty_aslp_state : entry:string -> exit:string -> unit -> aslp_state
 
-  val empty_lifter_state : ?generator:aslp_ids -> unit -> lifter_state
+  val empty_lifter_state : generator:aslp_ids -> unit -> lifter_state
   (** Constructs a new empty {!lifter_state}.
 
       Callers should consider whether they wish to re-use an existing
@@ -157,8 +157,7 @@ end = struct
     in
     { blocks; entry; exit }
 
-  let empty_lifter_state ?generator () =
-    let generator = Option.get_lazy empty_aslp_ids generator in
+  let empty_lifter_state ~generator () =
     let entry = gen_block_id generator in
     let exit = gen_block_id generator in
     {
@@ -205,455 +204,482 @@ end = struct
       ~source:first.exit ~target:second.entry
 end
 
-module Bincaml_IBI (S : sig
-  val bincaml_lifter_state : Aslp_state.lifter_state ref
-end) =
-struct
-  type bigint = Z.t
-  type bitvector = Bitvec.t
-  type expr = Expr.BasilExpr.t
-  type lexpr = Var.t
-  type stmt = Aslp_state.stmt
-  type branch = string
-  type ast = Aslp_state.aslp_state
-
-  let bincaml_emit stmt =
-    S.bincaml_lifter_state :=
-      Aslp_state.add_stmt_to_active !S.bincaml_lifter_state stmt
-
-  let bincaml_local_var name ty =
-    let id_name =
-      match Hashtbl.find_opt !S.bincaml_lifter_state.names name with
-      | None ->
-          let id_name =
-            Aslp_state.gen_local_id !S.bincaml_lifter_state.generator
-          in
-          Hashtbl.replace !S.bincaml_lifter_state.names name id_name;
-          id_name
-      | Some x -> x
-    in
-    Var.create id_name ty
-
-  let reset_ir () =
-    let generator = !S.bincaml_lifter_state.generator in
-    S.bincaml_lifter_state := Aslp_state.empty_lifter_state ~generator ()
-
-  let get_ir () = !S.bincaml_lifter_state.state
-  let bigint_of_string : string -> bigint = Z.of_string_base 10
-  let bigint_of_int : int -> bigint = Z.of_int
-  let bigint_zero : bigint = Z.zero
-  let bigint_add : bigint -> bigint -> bigint = Z.add
-  let bigint_sub : bigint -> bigint -> bigint = Z.sub
-  let bigint_mul : bigint -> bigint -> bigint = Z.mul
-  let undefined : unit -> expr = fun _ -> Expr.BasilExpr.bv_of_int ~size:0 0
-
-  let mkBits : bigint -> bigint -> bitvector =
-   fun size x -> Bitvec.create ~size:(Z.to_int size) x
-
-  let from_bitsLit : string -> bitvector =
-   fun bitstring ->
-    Bitvec.of_string
-      (Printf.sprintf "0b%s:bv%d" bitstring (String.length bitstring))
-
-  let frem_int : bigint -> bigint -> bigint =
-   fun x y -> Z.sub x (Z.mul y (Z.fdiv x y))
-
-  let extract_bits : bitvector -> bigint -> bigint -> bitvector =
-   fun x lo wd ->
-    let wd = Z.to_int wd and lo = Z.to_int lo in
-    let hi = lo + wd in
-    Bitvec.extract ~lo ~hi x (* [hi] is exclusive *)
-
-  (** [f_Elem_set operand_width elem_width operand elem_index elem_width elem]
-  *)
-  let f_Elem_set :
-      bigint ->
-      bigint ->
-      bitvector ->
-      bigint ->
-      bigint ->
-      bitvector ->
-      bitvector =
-   fun _ -> failwith "elem_set"
-
-  let f_eq_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ -> Bitvec.equal
-
-  let f_ne_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ a b -> not (Bitvec.equal a b)
-
-  let f_add_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> Bitvec.add
-
-  let f_sub_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> Bitvec.sub
-
-  let f_mul_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> Bitvec.mul
-
-  let f_and_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> Bitvec.bitand
-
-  let f_or_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> Bitvec.bitor
-
-  let f_eor_bits : bigint -> bitvector -> bitvector -> bitvector =
-   fun _ -> Bitvec.bitxor
-
-  let f_not_bits : bigint -> bitvector -> bitvector = fun _ -> Bitvec.bitnot
-
-  let f_slt_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ -> Bitvec.slt
-
-  let f_sle_bits : bigint -> bitvector -> bitvector -> bool =
-   fun _ -> Bitvec.sle
-
-  let f_zeros_bits : bigint -> bitvector =
-   fun size -> Bitvec.zero ~size:(Z.to_int size)
-
-  let f_ones_bits : bigint -> bitvector =
-   fun size -> Bitvec.ones ~size:(Z.to_int size)
-
-  (** [f_replicate_bits operand_width num_replications operand num_replications]
-  *)
-  let f_replicate_bits : bigint -> bigint -> bitvector -> bigint -> bitvector =
-   fun _ _ x copies -> Bitvec.repeat_bits ~copies:(Z.to_int copies) x
-
-  (** [f_append_bits w1 w2 x1 x2] *)
-  let f_append_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ _ -> Bitvec.concat
-
-  (** [f_ZeroExtend operand_width result_width operand result_width] *)
-  let f_ZeroExtend : bigint -> bigint -> bitvector -> bigint -> bitvector =
-   fun wd result_wd x _ ->
-    let extension = Z.(to_int (result_wd - wd)) in
-    Bitvec.zero_extend ~extension x
-
-  (** [f_SignExtend operand_width result_width operand result_width] *)
-  let f_SignExtend : bigint -> bigint -> bitvector -> bigint -> bitvector =
-   fun wd result_wd x _ ->
-    let extension = Z.(to_int (result_wd - wd)) in
-    Bitvec.sign_extend ~extension x
-
-  let unify_shift_widths apply_shift operand shift =
-    let extension = Bitvec.(size operand - size shift) in
-    let shift = Bitvec.zero_extend ~extension shift in
-    apply_shift operand shift
-
-  (** [f_lsl_bits operand_width shift_width operand shift] *)
-  let f_lsl_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ _ -> unify_shift_widths Bitvec.shl
-
-  (** [f_lsr_bits operand_width shift_width operand shift] *)
-  let f_lsr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ _ -> unify_shift_widths Bitvec.lshr
-
-  (** [f_asr_bits operand_width shift_width operand shift] *)
-  let f_asr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
-   fun _ _ -> unify_shift_widths Bitvec.ashr
-
-  (** [f_cvt_bits_uint operand_width operand] *)
-  let f_cvt_bits_uint : bigint -> bitvector -> bigint =
-   fun _ -> Bitvec.to_unsigned_bigint
-
-  let f_sdiv_int : bigint -> bigint -> bigint = fun _ -> failwith "sdiv int"
-  let f_shl_int : bigint -> bigint -> bigint = fun _ -> failwith "shl int"
-  let v_PSTATE_C : lexpr = Var.create "v_PSTATE_C" (Types.Bitvector 1)
-  let v_PSTATE_Z : lexpr = Var.create "v_PSTATE_Z" (Types.Bitvector 1)
-  let v_PSTATE_V : lexpr = Var.create "v_PSTATE_V" (Types.Bitvector 1)
-  let v_PSTATE_N : lexpr = Var.create "v_PSTATE_N" (Types.Bitvector 1)
-  let v__PC : lexpr = Var.create "v__PC" (Types.Bitvector 1)
-  let v__R : lexpr = Var.create "v__R" (Types.Bitvector 0)
-  let v__Z : lexpr = Var.create "v__Z" (Types.Bitvector 0)
-  let v_SP_EL0 : lexpr = Var.create "v_SP_EL0" (Types.Bitvector 1)
-  let v_FPSR : lexpr = Var.create "v_FPSR" (Types.Bitvector 1)
-  let v_FPCR : lexpr = Var.create "v_FPCR" (Types.Bitvector 1)
-  let v_PSTATE_A : lexpr = Var.create "v_PSTATE_A" (Types.Bitvector 1)
-  let v_PSTATE_D : lexpr = Var.create "v_PSTATE_D" (Types.Bitvector 1)
-  let v_PSTATE_DIT : lexpr = Var.create "v_PSTATE_DIT" (Types.Bitvector 1)
-  let v_PSTATE_F : lexpr = Var.create "v_PSTATE_F" (Types.Bitvector 1)
-  let v_PSTATE_I : lexpr = Var.create "v_PSTATE_I" (Types.Bitvector 1)
-  let v_PSTATE_PAN : lexpr = Var.create "v_PSTATE_PAN" (Types.Bitvector 1)
-  let v_PSTATE_SP : lexpr = Var.create "v_PSTATE_SP" (Types.Bitvector 1)
-  let v_PSTATE_SSBS : lexpr = Var.create "v_PSTATE_SSBS" (Types.Bitvector 1)
-  let v_PSTATE_TCO : lexpr = Var.create "v_PSTATE_TCO" (Types.Bitvector 1)
-  let v_PSTATE_UAO : lexpr = Var.create "v_PSTATE_UAO" (Types.Bitvector 1)
-  let v_PSTATE_BTYPE : lexpr = Var.create "v_PSTATE_BTYPE" (Types.Bitvector 1)
-
-  let v_BTypeCompatible : lexpr =
-    Var.create "v_BTypeCompatible" (Types.Bitvector 1)
-
-  let v___BranchTaken : lexpr = Var.create "v___BranchTaken" (Types.Bitvector 1)
-  let v_BTypeNext : lexpr = Var.create "v_BTypeNext" (Types.Bitvector 1)
-
-  let v___ExclusiveLocal : lexpr =
-    Var.create "v___ExclusiveLocal" (Types.Bitvector 1)
-
-  let f_switch_context : branch -> unit = fun _ -> failwith "f_switch_context"
-
-  let f_gen_branch : expr -> branch * branch * branch =
-   fun _ -> failwith "f_gen_branch"
-
-  let f_true_branch : branch * branch * branch -> branch =
-   fun _ -> failwith "f_true_branch"
-
-  let f_false_branch : branch * branch * branch -> branch =
-   fun _ -> failwith "f_false_branch"
-
-  let f_merge_branch : branch * branch * branch -> branch =
-   fun _ -> failwith "f_merge_branch"
-
-  let f_gen_assert : expr -> unit = fun _ -> failwith "f_gen_assert"
-
-  let f_gen_bit_lit : bigint -> bitvector -> expr =
-   fun _ bv -> Expr.BasilExpr.const (`Bitvector bv)
-
-  let f_gen_bool_lit : bool -> expr = fun _ -> failwith "f_gen_bool_lit"
-  let f_gen_int_lit : bigint -> expr = fun _ -> failwith "f_gen_int_lit"
-
-  let f_decl_bv : string -> bigint -> lexpr =
-   fun name size -> bincaml_local_var name (Types.Bitvector (Z.to_int size))
+module Bincaml_IBI = struct
+  module type S = sig
+    include
+      OfflineASL_pc.Instruction_building_interface.IBI
+        with type bitvector = Bitvec.t
+         and type ast = Aslp_state.aslp_state
+  end
+
+  module Make (S : sig
+    val bincaml_lifter_state : Aslp_state.lifter_state ref
+  end) =
+  struct
+    type bigint = Z.t
+    type bitvector = Bitvec.t
+    type expr = Expr.BasilExpr.t
+    type lexpr = Var.t
+    type stmt = Aslp_state.stmt
+    type branch = string
+    type ast = Aslp_state.aslp_state
+
+    let bincaml_emit stmt =
+      S.bincaml_lifter_state :=
+        Aslp_state.add_stmt_to_active !S.bincaml_lifter_state stmt
+
+    let bincaml_local_var name ty =
+      let id_name =
+        match Hashtbl.find_opt !S.bincaml_lifter_state.names name with
+        | None ->
+            let id_name =
+              Aslp_state.gen_local_id !S.bincaml_lifter_state.generator
+            in
+            Hashtbl.replace !S.bincaml_lifter_state.names name id_name;
+            id_name
+        | Some x -> x
+      in
+      Var.create id_name ty
+
+    let reset_ir () =
+      let generator = !S.bincaml_lifter_state.generator in
+      S.bincaml_lifter_state := Aslp_state.empty_lifter_state ~generator ()
+
+    let get_ir () = !S.bincaml_lifter_state.state
+    let bigint_of_string : string -> bigint = Z.of_string_base 10
+    let bigint_of_int : int -> bigint = Z.of_int
+    let bigint_zero : bigint = Z.zero
+    let bigint_add : bigint -> bigint -> bigint = Z.add
+    let bigint_sub : bigint -> bigint -> bigint = Z.sub
+    let bigint_mul : bigint -> bigint -> bigint = Z.mul
+    let undefined : unit -> expr = fun _ -> Expr.BasilExpr.bv_of_int ~size:0 0
+
+    let mkBits : bigint -> bigint -> bitvector =
+     fun size x -> Bitvec.create ~size:(Z.to_int size) x
+
+    let from_bitsLit : string -> bitvector =
+     fun bitstring ->
+      Bitvec.of_string
+        (Printf.sprintf "0b%s:bv%d" bitstring (String.length bitstring))
+
+    let frem_int : bigint -> bigint -> bigint =
+     fun x y -> Z.sub x (Z.mul y (Z.fdiv x y))
+
+    let extract_bits : bitvector -> bigint -> bigint -> bitvector =
+     fun x lo wd ->
+      let wd = Z.to_int wd and lo = Z.to_int lo in
+      let hi = lo + wd in
+      Bitvec.extract ~lo ~hi x (* [hi] is exclusive *)
+
+    (** [f_Elem_set operand_width elem_width operand elem_index elem_width elem]
+    *)
+    let f_Elem_set :
+        bigint ->
+        bigint ->
+        bitvector ->
+        bigint ->
+        bigint ->
+        bitvector ->
+        bitvector =
+     fun _ -> failwith "elem_set"
+
+    let f_eq_bits : bigint -> bitvector -> bitvector -> bool =
+     fun _ -> Bitvec.equal
+
+    let f_ne_bits : bigint -> bitvector -> bitvector -> bool =
+     fun _ a b -> not (Bitvec.equal a b)
+
+    let f_add_bits : bigint -> bitvector -> bitvector -> bitvector =
+     fun _ -> Bitvec.add
+
+    let f_sub_bits : bigint -> bitvector -> bitvector -> bitvector =
+     fun _ -> Bitvec.sub
+
+    let f_mul_bits : bigint -> bitvector -> bitvector -> bitvector =
+     fun _ -> Bitvec.mul
+
+    let f_and_bits : bigint -> bitvector -> bitvector -> bitvector =
+     fun _ -> Bitvec.bitand
+
+    let f_or_bits : bigint -> bitvector -> bitvector -> bitvector =
+     fun _ -> Bitvec.bitor
+
+    let f_eor_bits : bigint -> bitvector -> bitvector -> bitvector =
+     fun _ -> Bitvec.bitxor
+
+    let f_not_bits : bigint -> bitvector -> bitvector = fun _ -> Bitvec.bitnot
+
+    let f_slt_bits : bigint -> bitvector -> bitvector -> bool =
+     fun _ -> Bitvec.slt
+
+    let f_sle_bits : bigint -> bitvector -> bitvector -> bool =
+     fun _ -> Bitvec.sle
+
+    let f_zeros_bits : bigint -> bitvector =
+     fun size -> Bitvec.zero ~size:(Z.to_int size)
+
+    let f_ones_bits : bigint -> bitvector =
+     fun size -> Bitvec.ones ~size:(Z.to_int size)
+
+    (** [f_replicate_bits operand_width num_replications operand
+         num_replications] *)
+    let f_replicate_bits : bigint -> bigint -> bitvector -> bigint -> bitvector
+        =
+     fun _ _ x copies -> Bitvec.repeat_bits ~copies:(Z.to_int copies) x
+
+    (** [f_append_bits w1 w2 x1 x2] *)
+    let f_append_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector
+        =
+     fun _ _ -> Bitvec.concat
+
+    (** [f_ZeroExtend operand_width result_width operand result_width] *)
+    let f_ZeroExtend : bigint -> bigint -> bitvector -> bigint -> bitvector =
+     fun wd result_wd x _ ->
+      let extension = Z.(to_int (result_wd - wd)) in
+      Bitvec.zero_extend ~extension x
+
+    (** [f_SignExtend operand_width result_width operand result_width] *)
+    let f_SignExtend : bigint -> bigint -> bitvector -> bigint -> bitvector =
+     fun wd result_wd x _ ->
+      let extension = Z.(to_int (result_wd - wd)) in
+      Bitvec.sign_extend ~extension x
+
+    let unify_shift_widths apply_shift operand shift =
+      let extension = Bitvec.(size operand - size shift) in
+      let shift = Bitvec.zero_extend ~extension shift in
+      apply_shift operand shift
+
+    (** [f_lsl_bits operand_width shift_width operand shift] *)
+    let f_lsl_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
+     fun _ _ -> unify_shift_widths Bitvec.shl
+
+    (** [f_lsr_bits operand_width shift_width operand shift] *)
+    let f_lsr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
+     fun _ _ -> unify_shift_widths Bitvec.lshr
+
+    (** [f_asr_bits operand_width shift_width operand shift] *)
+    let f_asr_bits : bigint -> bigint -> bitvector -> bitvector -> bitvector =
+     fun _ _ -> unify_shift_widths Bitvec.ashr
+
+    (** [f_cvt_bits_uint operand_width operand] *)
+    let f_cvt_bits_uint : bigint -> bitvector -> bigint =
+     fun _ -> Bitvec.to_unsigned_bigint
+
+    let f_sdiv_int : bigint -> bigint -> bigint = fun _ -> failwith "sdiv int"
+    let f_shl_int : bigint -> bigint -> bigint = fun _ -> failwith "shl int"
+    let v_PSTATE_C : lexpr = Var.create "v_PSTATE_C" (Types.Bitvector 1)
+    let v_PSTATE_Z : lexpr = Var.create "v_PSTATE_Z" (Types.Bitvector 1)
+    let v_PSTATE_V : lexpr = Var.create "v_PSTATE_V" (Types.Bitvector 1)
+    let v_PSTATE_N : lexpr = Var.create "v_PSTATE_N" (Types.Bitvector 1)
+    let v__PC : lexpr = Var.create "v__PC" (Types.Bitvector 1)
+    let v__R : lexpr = Var.create "v__R" (Types.Bitvector 0)
+    let v__Z : lexpr = Var.create "v__Z" (Types.Bitvector 0)
+    let v_SP_EL0 : lexpr = Var.create "v_SP_EL0" (Types.Bitvector 1)
+    let v_FPSR : lexpr = Var.create "v_FPSR" (Types.Bitvector 1)
+    let v_FPCR : lexpr = Var.create "v_FPCR" (Types.Bitvector 1)
+    let v_PSTATE_A : lexpr = Var.create "v_PSTATE_A" (Types.Bitvector 1)
+    let v_PSTATE_D : lexpr = Var.create "v_PSTATE_D" (Types.Bitvector 1)
+    let v_PSTATE_DIT : lexpr = Var.create "v_PSTATE_DIT" (Types.Bitvector 1)
+    let v_PSTATE_F : lexpr = Var.create "v_PSTATE_F" (Types.Bitvector 1)
+    let v_PSTATE_I : lexpr = Var.create "v_PSTATE_I" (Types.Bitvector 1)
+    let v_PSTATE_PAN : lexpr = Var.create "v_PSTATE_PAN" (Types.Bitvector 1)
+    let v_PSTATE_SP : lexpr = Var.create "v_PSTATE_SP" (Types.Bitvector 1)
+    let v_PSTATE_SSBS : lexpr = Var.create "v_PSTATE_SSBS" (Types.Bitvector 1)
+    let v_PSTATE_TCO : lexpr = Var.create "v_PSTATE_TCO" (Types.Bitvector 1)
+    let v_PSTATE_UAO : lexpr = Var.create "v_PSTATE_UAO" (Types.Bitvector 1)
+    let v_PSTATE_BTYPE : lexpr = Var.create "v_PSTATE_BTYPE" (Types.Bitvector 1)
+
+    let v_BTypeCompatible : lexpr =
+      Var.create "v_BTypeCompatible" (Types.Bitvector 1)
+
+    let v___BranchTaken : lexpr =
+      Var.create "v___BranchTaken" (Types.Bitvector 1)
+
+    let v_BTypeNext : lexpr = Var.create "v_BTypeNext" (Types.Bitvector 1)
+
+    let v___ExclusiveLocal : lexpr =
+      Var.create "v___ExclusiveLocal" (Types.Bitvector 1)
+
+    let f_switch_context : branch -> unit = fun _ -> failwith "f_switch_context"
+
+    let f_gen_branch : expr -> branch * branch * branch =
+     fun _ -> failwith "f_gen_branch"
+
+    let f_true_branch : branch * branch * branch -> branch =
+     fun _ -> failwith "f_true_branch"
+
+    let f_false_branch : branch * branch * branch -> branch =
+     fun _ -> failwith "f_false_branch"
+
+    let f_merge_branch : branch * branch * branch -> branch =
+     fun _ -> failwith "f_merge_branch"
+
+    let f_gen_assert : expr -> unit = fun _ -> failwith "f_gen_assert"
 
-  let f_decl_bool : string -> lexpr = fun _ -> failwith "f_decl_bool"
-  let f_gen_load : lexpr -> expr = fun lhs -> Expr.BasilExpr.rvar lhs
+    let f_gen_bit_lit : bigint -> bitvector -> expr =
+     fun _ bv -> Expr.BasilExpr.const (`Bitvector bv)
 
-  let f_gen_store : lexpr -> expr -> unit =
-   fun lhs rhs ->
-    bincaml_emit
-      (Stmt.Instr_Assign { attrib = Attrib.empty; al = [ (lhs, rhs) ] })
+    let f_gen_bool_lit : bool -> expr = fun _ -> failwith "f_gen_bool_lit"
+    let f_gen_int_lit : bigint -> expr = fun _ -> failwith "f_gen_int_lit"
 
-  let f_gen_array_load : lexpr -> bigint -> expr =
-   fun array idx ->
-    match Var.name array with
-    | "v__R" ->
-        f_gen_load (Var.create ("v__R" ^ Z.to_string idx) (Types.Bitvector 64))
-    | x -> failwith x
+    let f_decl_bv : string -> bigint -> lexpr =
+     fun name size -> bincaml_local_var name (Types.Bitvector (Z.to_int size))
 
-  let f_gen_array_store : lexpr -> bigint -> expr -> unit =
-   fun array idx rhs ->
-    match Var.name array with
-    | "v__R" ->
-        f_gen_store
-          (Var.create ("v__R" ^ Z.to_string idx) (Types.Bitvector 64))
-          rhs
-    | x -> failwith x
+    let f_decl_bool : string -> lexpr = fun _ -> failwith "f_decl_bool"
+    let f_gen_load : lexpr -> expr = fun lhs -> Expr.BasilExpr.rvar lhs
 
-  let f_gen_Elem_read : bigint -> bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_Elem_read"
+    let f_gen_store : lexpr -> expr -> unit =
+     fun lhs rhs ->
+      bincaml_emit
+        (Stmt.Instr_Assign { attrib = Attrib.empty; al = [ (lhs, rhs) ] })
 
-  let f_gen_Elem_set : bigint -> bigint -> expr -> expr -> expr -> expr -> expr
-      =
-   fun _ -> failwith "f_gen_Elem_set"
+    let f_gen_array_load : lexpr -> bigint -> expr =
+     fun array idx ->
+      match Var.name array with
+      | "v__R" ->
+          f_gen_load
+            (Var.create ("v__R" ^ Z.to_string idx) (Types.Bitvector 64))
+      | x -> failwith x
 
-  (** [f_gen_Mem_set size address size acctype value] *)
-  let f_gen_Mem_set : bigint -> expr -> expr -> expr -> expr -> unit =
-   fun _ -> failwith "f_gen_Mem_set"
+    let f_gen_array_store : lexpr -> bigint -> expr -> unit =
+     fun array idx rhs ->
+      match Var.name array with
+      | "v__R" ->
+          f_gen_store
+            (Var.create ("v__R" ^ Z.to_string idx) (Types.Bitvector 64))
+            rhs
+      | x -> failwith x
 
-  (** [f_gen_Mem_read size address size acctype value] *)
-  let f_gen_Mem_read : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_Mem_read"
+    let f_gen_Elem_read : bigint -> bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_Elem_read"
 
-  let f_AtomicStart : unit -> unit = fun _ -> failwith "f_AtomicStart"
-  let f_AtomicEnd : unit -> unit = fun _ -> failwith "f_AtomicEnd"
+    let f_gen_Elem_set :
+        bigint -> bigint -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_Elem_set"
 
-  (** [f_gen_AArch64_MemTag_set address acctype value] *)
-  let f_gen_AArch64_MemTag_set : expr -> expr -> expr -> unit =
-   fun _ -> failwith "f_gen_AArch64_MemTag_set"
+    (** [f_gen_Mem_set size address size acctype value] *)
+    let f_gen_Mem_set : bigint -> expr -> expr -> expr -> expr -> unit =
+     fun _ -> failwith "f_gen_Mem_set"
 
-  (** [f_gen_AArch64_MemTag_read address acctype] *)
-  let f_gen_AArch64_MemTag_read : expr -> expr -> expr =
-   fun _ -> failwith "f_gen_AArch64_MemTag_read"
+    (** [f_gen_Mem_read size address size acctype value] *)
+    let f_gen_Mem_read : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_Mem_read"
 
-  let f_gen_and_bool : expr -> expr -> expr = fun _ -> failwith "f_gen_and_bool"
-  let f_gen_or_bool : expr -> expr -> expr = fun _ -> failwith "f_gen_or_bool"
-  let f_gen_not_bool : expr -> expr = fun _ -> failwith "f_gen_not_bool"
+    let f_AtomicStart : unit -> unit = fun _ -> failwith "f_AtomicStart"
+    let f_AtomicEnd : unit -> unit = fun _ -> failwith "f_AtomicEnd"
 
-  let f_gen_cvt_bits_uint : bigint -> expr -> expr =
-   fun _ -> failwith "f_gen_cvt_bits_uint"
+    (** [f_gen_AArch64_MemTag_set address acctype value] *)
+    let f_gen_AArch64_MemTag_set : expr -> expr -> expr -> unit =
+     fun _ -> failwith "f_gen_AArch64_MemTag_set"
 
-  let f_gen_eq_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_eq_bits"
+    (** [f_gen_AArch64_MemTag_read address acctype] *)
+    let f_gen_AArch64_MemTag_read : expr -> expr -> expr =
+     fun _ -> failwith "f_gen_AArch64_MemTag_read"
 
-  let f_gen_ne_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_ne_bits"
+    let f_gen_and_bool : expr -> expr -> expr =
+     fun _ -> failwith "f_gen_and_bool"
 
-  let f_gen_not_bits : bigint -> expr -> expr =
-   fun _ -> failwith "f_gen_not_bits"
+    let f_gen_or_bool : expr -> expr -> expr = fun _ -> failwith "f_gen_or_bool"
+    let f_gen_not_bool : expr -> expr = fun _ -> failwith "f_gen_not_bool"
 
-  let f_gen_cvt_bool_bv : expr -> expr = fun _ -> failwith "f_gen_cvt_bool_bv"
+    let f_gen_cvt_bits_uint : bigint -> expr -> expr =
+     fun _ -> failwith "f_gen_cvt_bits_uint"
 
-  let f_gen_or_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_or_bits"
+    let f_gen_eq_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_eq_bits"
 
-  let f_gen_eor_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_eor_bits"
+    let f_gen_ne_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_ne_bits"
 
-  let f_gen_and_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_and_bits"
+    let f_gen_not_bits : bigint -> expr -> expr =
+     fun _ -> failwith "f_gen_not_bits"
 
-  let f_gen_add_bits : bigint -> expr -> expr -> expr =
-   fun _ -> Expr.BasilExpr.binexp ?attrib:None ~op:`BVADD
+    let f_gen_cvt_bool_bv : expr -> expr = fun _ -> failwith "f_gen_cvt_bool_bv"
 
-  let f_gen_sub_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_sub_bits"
+    let f_gen_or_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_or_bits"
 
-  let f_gen_sdiv_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_sdiv_bits"
+    let f_gen_eor_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_eor_bits"
 
-  let f_gen_sle_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_sle_bits"
+    let f_gen_and_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_and_bits"
 
-  let f_gen_slt_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_slt_bits"
+    let f_gen_add_bits : bigint -> expr -> expr -> expr =
+     fun _ -> Expr.BasilExpr.binexp ?attrib:None ~op:`BVADD
 
-  let f_gen_mul_bits : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_mul_bits"
+    let f_gen_sub_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_sub_bits"
 
-  let f_gen_append_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_append_bits"
+    let f_gen_sdiv_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_sdiv_bits"
 
-  let f_gen_lsr_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_lsr_bits"
+    let f_gen_sle_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_sle_bits"
 
-  let f_gen_lsl_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ _ -> Expr.BasilExpr.binexp ?attrib:None ~op:`BVSHL
+    let f_gen_slt_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_slt_bits"
 
-  let f_gen_asr_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_asr_bits"
+    let f_gen_mul_bits : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_mul_bits"
 
-  (** [f_gen_replicate_bits operand_width num_replications operand
-       num_replications] *)
-  let f_gen_replicate_bits : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_replicate_bits"
+    let f_gen_append_bits : bigint -> bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_append_bits"
 
-  (** [f_gen_ZeroExtend operand_width result_width operand result_width] *)
-  let f_gen_ZeroExtend : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_ZeroExtend"
+    let f_gen_lsr_bits : bigint -> bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_lsr_bits"
 
-  (** [f_gen_SignExtend operand_width result_width operand result_width] *)
-  let f_gen_SignExtend : bigint -> bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_SignExtend"
+    let f_gen_lsl_bits : bigint -> bigint -> expr -> expr -> expr =
+     fun _ _ -> Expr.BasilExpr.binexp ?attrib:None ~op:`BVSHL
 
-  let f_gen_slice : expr -> bigint -> bigint -> expr =
-   fun _ -> failwith "f_gen_slice"
+    let f_gen_asr_bits : bigint -> bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_asr_bits"
 
-  (* {1 Floating point intrinsics} *)
+    (** [f_gen_replicate_bits operand_width num_replications operand
+         num_replications] *)
+    let f_gen_replicate_bits : bigint -> bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_replicate_bits"
 
-  let f_gen_FPCompare : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPCompare"
+    (** [f_gen_ZeroExtend operand_width result_width operand result_width] *)
+    let f_gen_ZeroExtend : bigint -> bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_ZeroExtend"
 
-  let f_gen_FPCompareEQ : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPCompareEQ"
+    (** [f_gen_SignExtend operand_width result_width operand result_width] *)
+    let f_gen_SignExtend : bigint -> bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_SignExtend"
 
-  let f_gen_FPCompareGE : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPCompareGE"
+    let f_gen_slice : expr -> bigint -> bigint -> expr =
+     fun _ -> failwith "f_gen_slice"
 
-  let f_gen_FPCompareGT : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPCompareGT"
+    (* {1 Floating point intrinsics} *)
 
-  let f_gen_FPAdd : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPAdd"
+    let f_gen_FPCompare : bigint -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPCompare"
 
-  let f_gen_FPSub : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPSub"
+    let f_gen_FPCompareEQ : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPCompareEQ"
 
-  let f_gen_FPMulAdd : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMulAdd"
+    let f_gen_FPCompareGE : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPCompareGE"
 
-  let f_gen_FPMulAddH : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMulAddH"
+    let f_gen_FPCompareGT : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPCompareGT"
 
-  let f_gen_FPMulX : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMulX"
+    let f_gen_FPAdd : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPAdd"
 
-  let f_gen_FPMul : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMul"
+    let f_gen_FPSub : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPSub"
 
-  let f_gen_FPDiv : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPDiv"
+    let f_gen_FPMulAdd : bigint -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMulAdd"
 
-  let f_gen_FPMin : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMin"
+    let f_gen_FPMulAddH : bigint -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMulAddH"
 
-  let f_gen_FPMinNum : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMinNum"
+    let f_gen_FPMulX : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMulX"
 
-  let f_gen_FPMax : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMax"
+    let f_gen_FPMul : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMul"
 
-  let f_gen_FPMaxNum : bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPMaxNum"
+    let f_gen_FPDiv : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPDiv"
 
-  let f_gen_FPRecpX : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPRecpX"
+    let f_gen_FPMin : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMin"
 
-  let f_gen_FPSqrt : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPSqrt"
+    let f_gen_FPMinNum : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMinNum"
 
-  let f_gen_FPRecipEstimate : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPRecipEstimate"
+    let f_gen_FPMax : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMax"
 
-  let f_gen_UnsignedRSqrtEstimate : bigint -> expr -> expr =
-   fun _ -> failwith "f_gen_UnsignedRSqrtEstimate"
+    let f_gen_FPMaxNum : bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPMaxNum"
 
-  let f_gen_FPRSqrtEstimate : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPRSqrtEstimate"
+    let f_gen_FPRecpX : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPRecpX"
 
-  let f_gen_BFAdd : expr -> expr -> expr = fun _ -> failwith "f_gen_BFAdd"
-  let f_gen_BFMul : expr -> expr -> expr = fun _ -> failwith "f_gen_BFMul"
+    let f_gen_FPSqrt : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPSqrt"
 
-  let f_gen_FPConvertBF : expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPConvertBF"
+    let f_gen_FPRecipEstimate : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPRecipEstimate"
 
-  let f_gen_FPRecipStepFused : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPRecipStepFused"
+    let f_gen_UnsignedRSqrtEstimate : bigint -> expr -> expr =
+     fun _ -> failwith "f_gen_UnsignedRSqrtEstimate"
 
-  let f_gen_FPRSqrtStepFused : bigint -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPRSqrtStepFused"
+    let f_gen_FPRSqrtEstimate : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPRSqrtEstimate"
 
-  let f_gen_FPToFixed :
-      bigint -> bigint -> expr -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPToFixed"
+    let f_gen_BFAdd : expr -> expr -> expr = fun _ -> failwith "f_gen_BFAdd"
+    let f_gen_BFMul : expr -> expr -> expr = fun _ -> failwith "f_gen_BFMul"
 
-  let f_gen_FixedToFP :
-      bigint -> bigint -> expr -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FixedToFP"
+    let f_gen_FPConvertBF : expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPConvertBF"
 
-  let f_gen_FPConvert : bigint -> bigint -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPConvert"
+    let f_gen_FPRecipStepFused : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPRecipStepFused"
 
-  let f_gen_FPRoundInt : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPRoundInt"
+    let f_gen_FPRSqrtStepFused : bigint -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPRSqrtStepFused"
 
-  let f_gen_FPRoundIntN : bigint -> expr -> expr -> expr -> expr -> expr =
-   fun _ -> failwith "f_gen_FPRoundIntN"
+    let f_gen_FPToFixed :
+        bigint -> bigint -> expr -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPToFixed"
 
-  let f_gen_FPToFixedJS_impl : bigint -> bigint -> expr -> expr -> expr -> expr
-      =
-   fun _ -> failwith "f_gen_FPToFixedJS_impl"
+    let f_gen_FixedToFP :
+        bigint -> bigint -> expr -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FixedToFP"
+
+    let f_gen_FPConvert : bigint -> bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPConvert"
+
+    let f_gen_FPRoundInt : bigint -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPRoundInt"
+
+    let f_gen_FPRoundIntN : bigint -> expr -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPRoundIntN"
+
+    let f_gen_FPToFixedJS_impl :
+        bigint -> bigint -> expr -> expr -> expr -> expr =
+     fun _ -> failwith "f_gen_FPToFixedJS_impl"
+  end
 end
 
-module type Bincaml_IBI = sig
-  include
-    OfflineASL_pc.Instruction_building_interface.IBI
-      with type bitvector = Bitvec.t
-       and type ast = Aslp_state.aslp_state
-end
+(** Builds a new {!module-type-Bincaml_IBI} with the given initial generator
+    state. *)
+let make_bincaml_ibi ~generator : (module Bincaml_IBI.S) =
+  let bincaml_lifter_state =
+    ref (Aslp_state.empty_lifter_state ~generator ())
+  in
+  (module Bincaml_IBI.Make(struct
+    let bincaml_lifter_state = bincaml_lifter_state
+  end))
+
+(** Builds a new {!module-type-Bincaml_IBI} where the ID generators are derived
+    from the given procedure. *)
+let make_bincaml_ibi_from_procedure proc : (module Bincaml_IBI.S) =
+  let block_ids = Procedure.block_ids proc
+  and local_ids = Procedure.local_ids proc in
+  make_bincaml_ibi
+    ~generator:(Aslp_state.aslp_ids_from_generators ~block_ids ~local_ids)
 
 let ensure_aslp_globals_exist prog = 9
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_opcode (module I : Bincaml_IBI) ~address opcode =
+let lift_opcode (module I : Bincaml_IBI.S) ~address opcode =
   Fun.protect ~finally:I.reset_ir (fun () ->
       OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
       I.get_ir ())
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_empty (module I : Bincaml_IBI) () =
+let lift_empty (module I : Bincaml_IBI.S) () =
   Fun.protect ~finally:I.reset_ir (fun () -> I.get_ir ())
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_code_block (module I : Bincaml_IBI) ~address opcodes =
+let lift_code_block (module I : Bincaml_IBI.S) ~address opcodes =
   opcodes
   |> Iter.foldi
        (fun acc i op ->

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -1,37 +1,6 @@
 open Lang
 open Common
 
-module Aslp_IDs = struct
-  type t = {
-    names : (string, int) Hashtbl.t;
-        (** Names and their associated unique ID. *)
-    count : int ref;
-        (** Count of unique IDs {i ever} emitted by this generator. Importantly,
-            this counts names which have been forgotten. *)
-  }
-
-  let create () = { names = Hashtbl.create 16; count = ref 0 }
-
-  (** Returns a fresh ID. *)
-  let fresh { names; count } =
-    let prev = !count in
-    count := prev + 1;
-    prev
-
-  (** Returns the ID associated with the given name, or creates and stores a new
-      ID if the name is not yet known. *)
-  let find name st =
-    match Hashtbl.find_opt st.names name with
-    | None ->
-        let n = fresh st in
-        Hashtbl.replace st.names name n;
-        n
-    | Some n -> n
-
-  (** Returns a copy of the {!t} which forgets all known name associations. *)
-  let forget st = { names = Hashtbl.copy st.names; count = ref !(st.count) }
-end
-
 module Aslp_state : sig
   (** {1 Types} *)
 
@@ -64,13 +33,17 @@ module Aslp_state : sig
       instructions. Or, it forms a part of {!lifter_state} for
       {i within}-instruction state. *)
 
-  type aslp_ids = { block_ids : Aslp_IDs.t; local_ids : Aslp_IDs.t }
+  type aslp_ids = {
+    block_ids : Fix.Gensym.generator;
+    local_ids : Fix.Gensym.generator;
+  }
   (** Generators for unique IDs used by the offline lifter. *)
 
   type lifter_state = {
     active : string;
     state : aslp_state;
     generator : aslp_ids;
+    names : (string, string) Hashtbl.t;
   }
   (** Intermediate offline lifter state while {i within} one particular
       instruction.
@@ -95,7 +68,7 @@ module Aslp_state : sig
 
   val initial_aslp_ids : unit -> aslp_ids
   val gen_block_id : aslp_ids -> string
-  val gen_local_id : aslp_ids -> string -> string
+  val gen_local_id : aslp_ids -> string
 
   (** Returns a copy of the given lifter ID generator, but with the local
       {i names} forgotten. This means that existing local names will become
@@ -140,21 +113,25 @@ end = struct
   }
   [@@deriving show]
 
-  type aslp_ids = { block_ids : Aslp_IDs.t; local_ids : Aslp_IDs.t }
+  type aslp_ids = {
+    block_ids : Fix.Gensym.generator;
+    local_ids : Fix.Gensym.generator;
+  }
 
   let initial_aslp_ids () =
-    { block_ids = Aslp_IDs.create (); local_ids = Aslp_IDs.create () }
+    { block_ids = Fix.Gensym.generator (); local_ids = Fix.Gensym.generator () }
 
   let gen_block_id gens =
-    Printf.sprintf "block_%d" @@ Aslp_IDs.fresh gens.block_ids
+    Printf.sprintf "block_%d" @@ Fix.Gensym.fresh gens.block_ids
 
-  let gen_local_id gens name =
-    Printf.sprintf "var_%d" @@ Aslp_IDs.find name gens.local_ids
+  let gen_local_id gens =
+    Printf.sprintf "var_%d" @@ Fix.Gensym.fresh gens.block_ids
 
   type lifter_state = {
     active : string;
     state : aslp_state;
     generator : aslp_ids; [@opaque]
+    names : (string, string) Hashtbl.t;
   }
   [@@deriving show]
 
@@ -173,7 +150,12 @@ end = struct
     let generator = Option.get_lazy initial_aslp_ids generator in
     let entry = gen_block_id generator in
     let exit = gen_block_id generator in
-    { active = entry; state = empty_aslp_state ~entry ~exit (); generator }
+    {
+      active = entry;
+      state = empty_aslp_state ~entry ~exit ();
+      names = Hashtbl.create 16;
+      generator;
+    }
 
   let map_aslp_block_names f { assume; stmts; succs } =
     let succs = List.map f succs in
@@ -200,9 +182,9 @@ end = struct
     in
     { state with blocks }
 
-  let add_stmt_to_active { active; state; generator } stmt =
-    let state = add_stmt_to_block state active stmt in
-    { active; state; generator }
+  let add_stmt_to_active lifter_state stmt =
+    let state = add_stmt_to_block lifter_state.state lifter_state.active stmt in
+    { lifter_state with state }
 
   let add_goto aslp_state ~source ~target =
     let blocks =
@@ -242,8 +224,17 @@ struct
       Aslp_state.add_stmt_to_active !S.bincaml_lifter_state stmt
 
   let bincaml_local_var name ty =
-    let name = Aslp_state.gen_local_id !S.bincaml_lifter_state.generator name in
-    Var.create name ty
+    let id_name =
+      match Hashtbl.find_opt !S.bincaml_lifter_state.names name with
+      | None ->
+          let id_name =
+            Aslp_state.gen_local_id !S.bincaml_lifter_state.generator
+          in
+          Hashtbl.replace !S.bincaml_lifter_state.names name id_name;
+          id_name
+      | Some x -> x
+    in
+    Var.create id_name ty
 
   let reset_ir () =
     let generator = !S.bincaml_lifter_state.generator in

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -205,24 +205,11 @@ end = struct
 end
 
 module Bincaml_IBI = struct
-  module type S = sig
-    include
-      OfflineASL_pc.Instruction_building_interface.IBI
-        with type bitvector = Bitvec.t
-         and type ast = Aslp_state.aslp_state
-  end
-
   module Make (S : sig
     val bincaml_lifter_state : Aslp_state.lifter_state ref
   end) =
   struct
-    type bigint = Z.t
-    type bitvector = Bitvec.t
-    type expr = Expr.BasilExpr.t
-    type lexpr = Var.t
-    type stmt = Aslp_state.stmt
-    type branch = string
-    type ast = Aslp_state.aslp_state
+    (** {2 Bincaml-specific utility functions} *)
 
     let bincaml_emit stmt =
       S.bincaml_lifter_state :=
@@ -240,6 +227,16 @@ module Bincaml_IBI = struct
         | Some x -> x
       in
       Var.create id_name ty
+
+    (** {2 Instruction building interface implementation} *)
+
+    type bigint = Z.t
+    type bitvector = Bitvec.t
+    type expr = Expr.BasilExpr.t
+    type lexpr = Var.t
+    type stmt = Aslp_state.stmt
+    type branch = string
+    type ast = Aslp_state.aslp_state
 
     let reset_ir () =
       let generator = !S.bincaml_lifter_state.generator in
@@ -646,40 +643,45 @@ module Bincaml_IBI = struct
         bigint -> bigint -> expr -> expr -> expr -> expr =
      fun _ -> failwith "f_gen_FPToFixedJS_impl"
   end
+
+  module type IBI = sig
+    include
+      OfflineASL_pc.Instruction_building_interface.IBI
+        with type bitvector = Lang.Common.Bitvec.t
+         and type ast = Aslp_state.aslp_state
+  end
+
+  (** Builds a new {!IBI} with the given initial generator state. *)
+  let from_generator generator : (module IBI) =
+    let bincaml_lifter_state =
+      ref (Aslp_state.empty_lifter_state ~generator ())
+    in
+    (module Make (struct
+      let bincaml_lifter_state = bincaml_lifter_state
+    end))
+
+  (** Builds a new {!IBI} where the ID generators are derived from the given
+      procedure. *)
+  let from_bincaml_procedure proc : (module IBI) =
+    let block_ids = Procedure.block_ids proc
+    and local_ids = Procedure.local_ids proc in
+    from_generator (Aslp_state.aslp_ids_from_generators ~block_ids ~local_ids)
 end
-
-(** Builds a new {!module-type-Bincaml_IBI} with the given initial generator
-    state. *)
-let make_bincaml_ibi ~generator : (module Bincaml_IBI.S) =
-  let bincaml_lifter_state =
-    ref (Aslp_state.empty_lifter_state ~generator ())
-  in
-  (module Bincaml_IBI.Make(struct
-    let bincaml_lifter_state = bincaml_lifter_state
-  end))
-
-(** Builds a new {!module-type-Bincaml_IBI} where the ID generators are derived
-    from the given procedure. *)
-let make_bincaml_ibi_from_procedure proc : (module Bincaml_IBI.S) =
-  let block_ids = Procedure.block_ids proc
-  and local_ids = Procedure.local_ids proc in
-  make_bincaml_ibi
-    ~generator:(Aslp_state.aslp_ids_from_generators ~block_ids ~local_ids)
 
 let ensure_aslp_globals_exist prog = 9
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_opcode (module I : Bincaml_IBI.S) ~address opcode =
+let lift_opcode (module I : Bincaml_IBI.IBI) ~address opcode =
   Fun.protect ~finally:I.reset_ir (fun () ->
       OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
       I.get_ir ())
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_empty (module I : Bincaml_IBI.S) () =
+let lift_empty (module I : Bincaml_IBI.IBI) () =
   Fun.protect ~finally:I.reset_ir (fun () -> I.get_ir ())
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_code_block (module I : Bincaml_IBI.S) ~address opcodes =
+let lift_code_block (module I : Bincaml_IBI.IBI) ~address opcodes =
   opcodes
   |> Iter.foldi
        (fun acc i op ->

--- a/lib/transforms/aslp.ml
+++ b/lib/transforms/aslp.ml
@@ -205,6 +205,7 @@ end = struct
 end
 
 module Bincaml_IBI = struct
+  (** Makes a concrete module which implements {!Bincaml_IBI.IBI}. *)
   module Make (S : sig
     val bincaml_lifter_state : Aslp_state.lifter_state ref
   end) =
@@ -644,6 +645,9 @@ module Bincaml_IBI = struct
      fun _ -> failwith "f_gen_FPToFixedJS_impl"
   end
 
+  (** Abstract Bincaml IBI signature. Defines the input type as
+      {!Lang.Common.Bitvec.t} and the output type as {!Aslp_state.aslp_state}
+      but leaving other types opaque. *)
   module type IBI = sig
     include
       OfflineASL_pc.Instruction_building_interface.IBI

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -3,9 +3,7 @@ open Common
 open Transforms.Aslp
 
 let%expect_test "lift: add x1, x2, x3, lsl #4" =
-  let bincaml_aslp_state =
-    ref (Aslp_state.empty_lifter_state ~entry:"entry" ~exit:"exit" ())
-  in
+  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
   let module I = Bincaml_IBI (struct
     let bincaml_lifter_state = bincaml_aslp_state
   end) in
@@ -29,9 +27,7 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
     |}]
 
 let%expect_test "lift 2x: mov x1, #0xabcd" =
-  let bincaml_aslp_state =
-    ref (Aslp_state.empty_lifter_state ~entry:"entry" ~exit:"exit" ())
-  in
+  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
   let module I = Bincaml_IBI (struct
     let bincaml_lifter_state = bincaml_aslp_state
   end) in
@@ -52,12 +48,8 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
       "1_block_2"
       -> { Aslp.Aslp_state.assume = None;
            stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_block_3"] },
-      "1_block_3" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
-      "entryyyy"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["exittt"] },
-      "exittt"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_block_0"] };
-      entry = "entryyyy"; exit = "1_block_3" }
+      "1_block_3" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
+      entry = "0_block_0"; exit = "1_block_3" }
     |}]
 
 let%expect_test "aslp integration basic" =

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -14,18 +14,17 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
       (Bitvec.of_string "0x8b031041:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_state x;
-  [%expect
-    {|
-    { Aslp.Aslp_state.blocks = "entry"
+  [%expect {|
+    { Aslp.Aslp_state.blocks = "entry_1"
       -> { Aslp.Aslp_state.assume = None;
            stmts =
            [var X.read8__2:bv64 := v__R2:bv64;
              var X.read14__3:bv64 := v__R3:bv64;
              var v__R1:bv64 := bvadd(X.read8__2:bv64, bvshl(X.read14__3:bv64, 0x4:bv12))
              ];
-           succs = ["exit"] },
-      "exit" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
-      entry = "entry"; exit = "exit" }
+           succs = ["exit_1"] },
+      "exit_1" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
+      entry = "entry_1"; exit = "exit_1" }
     |}]
 
 let%expect_test "lift 2x: mov x1, #0xabcd" =
@@ -40,21 +39,21 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
          (Bitvec.of_string "0xd29579a1:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_state x;
-  [%expect
-    {|
-    { Aslp.Aslp_state.blocks = "0_entry"
+  [%expect {|
+    { Aslp.Aslp_state.blocks = "0_entry_1"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_exit"] },
-      "0_exit"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_entry"] },
-      "1_entry"
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_exit_1"] },
+      "0_exit_1"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_entry_2"] },
+      "1_entry_2"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_exit"] },
-      "1_exit" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
-      "entry" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["exit"] },
-      "exit"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_entry"] };
-      entry = "entry"; exit = "1_exit" }
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_exit_2"] },
+      "1_exit_2" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
+      "entryyyy"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["exittt"] },
+      "exittt"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_entry_1"] };
+      entry = "entryyyy"; exit = "1_exit_2" }
     |}]
 
 let%expect_test "aslp integration basic" =

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -3,7 +3,9 @@ open Common
 open Transforms.Aslp
 
 let%expect_test "lift: add x1, x2, x3, lsl #4" =
-  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
+  let bincaml_aslp_state =
+    ref (Aslp_state.empty_lifter_state ~entry:"entry" ~exit:"exit" ())
+  in
   let module I = Bincaml_IBI (struct
     let bincaml_lifter_state = bincaml_aslp_state
   end) in
@@ -14,19 +16,22 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
       (Bitvec.of_string "0x8b031041:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_state x;
-  [%expect {|
-    { Aslp.Aslp_state.blocks = "block_2"
+  [%expect
+    {|
+    { Aslp.Aslp_state.blocks = "block_0"
       -> { Aslp.Aslp_state.assume = None;
            stmts =
-           [var var_4:bv64 := v__R2:bv64; var var_5:bv64 := v__R3:bv64;
-             var v__R1:bv64 := bvadd(var_4:bv64, bvshl(var_5:bv64, 0x4:bv12))];
-           succs = ["block_3"] },
-      "block_3" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
-      entry = "block_2"; exit = "block_3" }
+           [var var_2:bv64 := v__R2:bv64; var var_3:bv64 := v__R3:bv64;
+             var v__R1:bv64 := bvadd(var_2:bv64, bvshl(var_3:bv64, 0x4:bv12))];
+           succs = ["block_1"] },
+      "block_1" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
+      entry = "block_0"; exit = "block_1" }
     |}]
 
 let%expect_test "lift 2x: mov x1, #0xabcd" =
-  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
+  let bincaml_aslp_state =
+    ref (Aslp_state.empty_lifter_state ~entry:"entry" ~exit:"exit" ())
+  in
   let module I = Bincaml_IBI (struct
     let bincaml_lifter_state = bincaml_aslp_state
   end) in
@@ -37,21 +42,22 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
          (Bitvec.of_string "0xd29579a1:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_state x;
-  [%expect {|
-    { Aslp.Aslp_state.blocks = "0_block_2"
+  [%expect
+    {|
+    { Aslp.Aslp_state.blocks = "0_block_0"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_block_3"] },
-      "0_block_3"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_block_4"] },
-      "1_block_4"
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_block_1"] },
+      "0_block_1"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_block_2"] },
+      "1_block_2"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_block_5"] },
-      "1_block_5" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_block_3"] },
+      "1_block_3" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
       "entryyyy"
       -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["exittt"] },
       "exittt"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_block_2"] };
-      entry = "entryyyy"; exit = "1_block_5" }
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_block_0"] };
+      entry = "entryyyy"; exit = "1_block_3" }
     |}]
 
 let%expect_test "aslp integration basic" =

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -15,16 +15,14 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
   in
   print_endline @@ Aslp_state.show_aslp_state x;
   [%expect {|
-    { Aslp.Aslp_state.blocks = "entry_1"
+    { Aslp.Aslp_state.blocks = "block_2"
       -> { Aslp.Aslp_state.assume = None;
            stmts =
-           [var X.read8__2:bv64 := v__R2:bv64;
-             var X.read14__3:bv64 := v__R3:bv64;
-             var v__R1:bv64 := bvadd(X.read8__2:bv64, bvshl(X.read14__3:bv64, 0x4:bv12))
-             ];
-           succs = ["exit_1"] },
-      "exit_1" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
-      entry = "entry_1"; exit = "exit_1" }
+           [var var_4:bv64 := v__R2:bv64; var var_5:bv64 := v__R3:bv64;
+             var v__R1:bv64 := bvadd(var_4:bv64, bvshl(var_5:bv64, 0x4:bv12))];
+           succs = ["block_3"] },
+      "block_3" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
+      entry = "block_2"; exit = "block_3" }
     |}]
 
 let%expect_test "lift 2x: mov x1, #0xabcd" =
@@ -40,20 +38,20 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
   in
   print_endline @@ Aslp_state.show_aslp_state x;
   [%expect {|
-    { Aslp.Aslp_state.blocks = "0_entry_1"
+    { Aslp.Aslp_state.blocks = "0_block_2"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_exit_1"] },
-      "0_exit_1"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_entry_2"] },
-      "1_entry_2"
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_block_3"] },
+      "0_block_3"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_block_4"] },
+      "1_block_4"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_exit_2"] },
-      "1_exit_2" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_block_5"] },
+      "1_block_5" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] },
       "entryyyy"
       -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["exittt"] },
       "exittt"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_entry_1"] };
-      entry = "entryyyy"; exit = "1_exit_2" }
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["0_block_2"] };
+      entry = "entryyyy"; exit = "1_block_5" }
     |}]
 
 let%expect_test "aslp integration basic" =

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -2,6 +2,23 @@ open Lang
 open Common
 open Transforms.Aslp
 
+let%expect_test "lift empty" =
+  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
+  let module I = Bincaml_IBI (struct
+    let bincaml_lifter_state = bincaml_aslp_state
+  end) in
+  let x =
+    lift_code_block (module I) ~address:(Bitvec.zero ~size:64) @@ Iter.empty
+  in
+  print_endline @@ Aslp_state.show_aslp_state x;
+  [%expect
+    {|
+    { Aslp.Aslp_state.blocks = "block_0"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["block_1"] },
+      "block_1" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
+      entry = "block_0"; exit = "block_1" }
+    |}]
+
 let%expect_test "lift: add x1, x2, x3, lsl #4" =
   let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
   let module I = Bincaml_IBI (struct

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -19,8 +19,8 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
     { Aslp.Aslp_state.blocks = "block_0"
       -> { Aslp.Aslp_state.assume = None;
            stmts =
-           [var var_2:bv64 := v__R2:bv64; var var_3:bv64 := v__R3:bv64;
-             var v__R1:bv64 := bvadd(var_2:bv64, bvshl(var_3:bv64, 0x4:bv12))];
+           [var var_0:bv64 := v__R2:bv64; var var_1:bv64 := v__R3:bv64;
+             var v__R1:bv64 := bvadd(var_0:bv64, bvshl(var_1:bv64, 0x4:bv12))];
            succs = ["block_1"] },
       "block_1" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
       entry = "block_0"; exit = "block_1" }
@@ -40,16 +40,16 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
   print_endline @@ Aslp_state.show_aslp_state x;
   [%expect
     {|
-    { Aslp.Aslp_state.blocks = "0_block_0"
+    { Aslp.Aslp_state.blocks = "block_0"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["0_block_1"] },
-      "0_block_1"
-      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["1_block_2"] },
-      "1_block_2"
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["block_1"] },
+      "block_1"
+      -> { Aslp.Aslp_state.assume = None; stmts = []; succs = ["block_2"] },
+      "block_2"
       -> { Aslp.Aslp_state.assume = None;
-           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["1_block_3"] },
-      "1_block_3" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
-      entry = "0_block_0"; exit = "1_block_3" }
+           stmts = [var v__R1:bv64 := 0xabcd:bv64]; succs = ["block_3"] },
+      "block_3" -> { Aslp.Aslp_state.assume = None; stmts = []; succs = [] };
+      entry = "block_0"; exit = "block_3" }
     |}]
 
 let%expect_test "aslp integration basic" =

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -3,8 +3,7 @@ open Common
 open Transforms.Aslp
 
 let%expect_test "lift empty" =
-  let module I =
-    (val make_bincaml_ibi ~generator:(Aslp_state.empty_aslp_ids ()))
+  let module I = (val Bincaml_IBI.from_generator (Aslp_state.empty_aslp_ids ()))
   in
   let x =
     lift_code_block (module I) ~address:(Bitvec.zero ~size:64) @@ Iter.empty
@@ -19,8 +18,7 @@ let%expect_test "lift empty" =
     |}]
 
 let%expect_test "lift: add x1, x2, x3, lsl #4" =
-  let module I =
-    (val make_bincaml_ibi ~generator:(Aslp_state.empty_aslp_ids ()))
+  let module I = (val Bincaml_IBI.from_generator (Aslp_state.empty_aslp_ids ()))
   in
   let x =
     lift_opcode
@@ -42,8 +40,7 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
     |}]
 
 let%expect_test "lift 2x: mov x1, #0xabcd" =
-  let module I =
-    (val make_bincaml_ibi ~generator:(Aslp_state.empty_aslp_ids ()))
+  let module I = (val Bincaml_IBI.from_generator (Aslp_state.empty_aslp_ids ()))
   in
   let x =
     lift_code_block (module I) ~address:(Bitvec.zero ~size:64)

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -3,10 +3,9 @@ open Common
 open Transforms.Aslp
 
 let%expect_test "lift empty" =
-  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
-  let module I = Bincaml_IBI (struct
-    let bincaml_lifter_state = bincaml_aslp_state
-  end) in
+  let module I =
+    (val make_bincaml_ibi ~generator:(Aslp_state.empty_aslp_ids ()))
+  in
   let x =
     lift_code_block (module I) ~address:(Bitvec.zero ~size:64) @@ Iter.empty
   in
@@ -20,10 +19,9 @@ let%expect_test "lift empty" =
     |}]
 
 let%expect_test "lift: add x1, x2, x3, lsl #4" =
-  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
-  let module I = Bincaml_IBI (struct
-    let bincaml_lifter_state = bincaml_aslp_state
-  end) in
+  let module I =
+    (val make_bincaml_ibi ~generator:(Aslp_state.empty_aslp_ids ()))
+  in
   let x =
     lift_opcode
       (module I)
@@ -44,10 +42,9 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
     |}]
 
 let%expect_test "lift 2x: mov x1, #0xabcd" =
-  let bincaml_aslp_state = ref (Aslp_state.empty_lifter_state ()) in
-  let module I = Bincaml_IBI (struct
-    let bincaml_lifter_state = bincaml_aslp_state
-  end) in
+  let module I =
+    (val make_bincaml_ibi ~generator:(Aslp_state.empty_aslp_ids ()))
+  in
   let x =
     lift_code_block (module I) ~address:(Bitvec.zero ~size:64)
     @@ Iter.doubleton


### PR DESCRIPTION
This makes a new hashtable to associate each Aslp variable name with a counter. This also fixes the problem of dots inside variable names. 

