### PR TITLE
Narrowing

### DIFF
--- a/lib/analysis/dataflow_graph.ml
+++ b/lib/analysis/dataflow_graph.ml
@@ -395,13 +395,6 @@ module type DFAnalysis = sig
   include Lattice_types.StateDomain with type t := t with type key_t = Var.t
 end
 
-module type NarrowingDFAnalysis = sig
-  type t
-
-  include
-    Lattice_types.NarrowingStateDomain with type t := t with type key_t = Var.t
-end
-
 open struct
   module DFDomain
       (G :
@@ -499,7 +492,7 @@ open struct
         Bincaml_util.Reverse_graph.GraphSig
           with type V.t = Vertex.t
           with type t = DFGraph.t)
-      (D : NarrowingDFAnalysis) =
+      (D : DFAnalysis) =
   struct
     module Domain =
       DFDomain (G) (D)
@@ -575,7 +568,7 @@ end
 
 (** Backwards dataflow analysis over dfg that narrows after widening to a
     fixpoint *)
-module AnalysisRevNarrowing (AD : NarrowingDFAnalysis) = struct
+module AnalysisRevNarrowing (AD : DFAnalysis) = struct
   module A = DataflowAnalysis (Bincaml_util.Reverse_graph.RevG (DFGraph)) (AD)
   module N = DataflowNarrowing (Bincaml_util.Reverse_graph.RevG (DFGraph)) (AD)
   module D = AD
@@ -608,7 +601,7 @@ end
 
 (** Forwards dataflow analysis over dfg that narrows after widening to a
     fixpoint *)
-module AnalysisFwdNarrowing (AD : NarrowingDFAnalysis) = struct
+module AnalysisFwdNarrowing (AD : DFAnalysis) = struct
   module A = DataflowAnalysis (DFGraph) (AD)
   module N = DataflowNarrowing (DFGraph) (AD)
   module D = AD

--- a/lib/analysis/dataflow_graph.ml
+++ b/lib/analysis/dataflow_graph.ml
@@ -390,11 +390,80 @@ end)
 (** Type of a dataflow analysis domain: this needs at minimum a view of variable
     state, lattice order, and transfer function *)
 module type DFAnalysis = sig
-  include Lattice_types.StateAbstraction with type key_t = Var.t
+  type t
+
   include Lattice_types.StateDomain with type t := t with type key_t = Var.t
 end
 
+module type NarrowingDFAnalysis = sig
+  type t
+
+  include
+    Lattice_types.NarrowingStateDomain with type t := t with type key_t = Var.t
+end
+
 open struct
+  module DFDomain
+      (G :
+        Bincaml_util.Reverse_graph.GraphSig
+          with type V.t = Vertex.t
+          with type t = DFGraph.t)
+      (D : DFAnalysis)
+      (W : sig
+        val widening : D.V.t -> D.V.t -> D.V.t
+      end) =
+  struct
+    include D
+
+    type edge = G.edge
+
+    (** Analysis function specificatlly for the flow insensitive fixed point,
+        hence incorporates joins etc. *)
+    let analyze_vert_intra ~widen data (v : Vertex.t) =
+      let r =
+        match snd v with
+        | Vertex.(Phi { lhs; rhs }) ->
+            (* On widening points widen with the old value, else replace the
+               old value entirely *)
+            let widen = if widen then W.widening else flip const in
+            let olhs = D.read lhs data in
+            let nlhs =
+              rhs
+              |> List.fold_left (fun a v -> V.join a (D.read v data)) D.V.bottom
+            in
+            let v = widen olhs nlhs in
+            if not (D.V.equal olhs v) then Some (update lhs v data) else None
+        | Vertex.(Stmt (_, stmt)) ->
+            let read v = D.read v data in
+            let s' =
+              D.transfer_state read stmt
+              |> Iter.filter_map (fun (v, s) ->
+                  let vv = read v in
+                  let s = if widen then W.widening vv s else s in
+                  if V.equal vv s then None else Some (v, s))
+            in
+            if Iter.is_empty s' then None
+            else (
+              log_debug (fun () ->
+                  Iter.to_string
+                    (function k, vvv -> Var.to_string k ^ "->" ^ V.show vvv)
+                    s');
+              Some (s' |> Iter.fold (fun acc (k, v) -> update k v acc) data))
+        | Entry -> None
+        | Return -> None
+      in
+      r
+
+    let analyze_vert (v : Vertex.t) data =
+      Option.get_or ~default:data (analyze_vert_intra ~widen:false data v)
+
+    let analyze (edge : G.edge) data =
+      (* this gets swapped based on graph direction so is always the logical
+         predecessor (dataflow dependency)
+      *)
+      analyze_vert (G.E.src edge) data
+  end
+
   (** Dataflow analysis that is parametric in analysis direction, via functor
       argument {! G} which may present either a forwards or backwards view of
       the graph. *)
@@ -405,57 +474,11 @@ open struct
           with type t = DFGraph.t)
       (D : DFAnalysis) =
   struct
-    module Domain = struct
-      include D
-
-      type edge = G.edge
-
-      (** Analysis function specificatlly for the flow insensitive fixed point,
-          hence incorporates joins etc. *)
-      let analyze_vert_intra ~widen data (v : Vertex.t) =
-        let r =
-          match snd v with
-          | Vertex.(Phi { lhs; rhs }) ->
-              let join = if widen then V.widening else V.join in
-              let olhs = D.read lhs data in
-              let nlhs =
-                rhs
-                |> List.fold_left
-                     (fun a v -> V.join a (D.read v data))
-                     D.V.bottom
-              in
-              let v = join olhs nlhs in
-              if not (D.V.equal olhs v) then Some (update lhs v data) else None
-          | Vertex.(Stmt (_, stmt)) ->
-              let read v = D.read v data in
-              let s' =
-                D.transfer_state read stmt
-                |> Iter.filter_map (fun (v, s) ->
-                    let vv = read v in
-                    let s = if widen then V.widening vv s else s in
-                    if V.equal vv s then None else Some (v, s))
-              in
-              if Iter.is_empty s' then None
-              else (
-                log_debug (fun () ->
-                    Iter.to_string
-                      (function k, vvv -> Var.to_string k ^ "->" ^ V.show vvv)
-                      s');
-                Some (s' |> Iter.fold (fun acc (k, v) -> update k v acc) data))
-          | Entry -> None
-          | Return -> None
-        in
-        r
-
-      let analyze_vert (v : Vertex.t) data =
-        Option.get_or ~default:data (analyze_vert_intra ~widen:false data v)
-
-      let analyze (edge : G.edge) data =
-        (* this gets swapped based on graph direction so is always the logical
-         predecessor (dataflow dependency)
-      *)
-        analyze_vert (G.E.src edge) data
-    end
+    module Domain =
+      DFDomain (G) (D)
+        (struct
+          let widening = D.V.widening
+        end)
 
     module Topo = Graph.WeakTopological.Make (G)
     module DFGChaoticIter = Graph.ChaoticIteration.Make (G) (Domain)
@@ -468,6 +491,30 @@ open struct
     let analyse root ~init ~widen_set ~delay_widen g =
       let scc = Topo.recursive_scc g root in
       let f_init v = init in
+      DFGChaoticIter.recurse g scc f_init widen_set delay_widen
+  end
+
+  module DataflowNarrowing
+      (G :
+        Bincaml_util.Reverse_graph.GraphSig
+          with type V.t = Vertex.t
+          with type t = DFGraph.t)
+      (D : NarrowingDFAnalysis) =
+  struct
+    module Domain =
+      DFDomain (G) (D)
+        (struct
+          let widening = D.V.narrowing
+        end)
+
+    module Topo = Graph.WeakTopological.Make (G)
+    module DFGChaoticIter = Graph.ChaoticIteration.Make (G) (Domain)
+
+    let narrow root ~result ~widen_set ~delay_widen g =
+      let scc = Topo.recursive_scc g root in
+      let f_init v =
+        DFGChaoticIter.M.find_opt v result |> Option.get_or ~default:D.bottom
+      in
       DFGChaoticIter.recurse g scc f_init widen_set delay_widen
   end
 end
@@ -524,6 +571,72 @@ module AnalysisFwd (AD : DFAnalysis) = struct
   let flow_insensitive p =
     SimpleSolver.fixpoint_fwd ~initial:(AD.init p)
       ~transfer:A.Domain.analyze_vert_intra p
+end
+
+(** Backwards dataflow analysis over dfg that narrows after widening to a
+    fixpoint *)
+module AnalysisRevNarrowing (AD : NarrowingDFAnalysis) = struct
+  module A = DataflowAnalysis (Bincaml_util.Reverse_graph.RevG (DFGraph)) (AD)
+  module N = DataflowNarrowing (Bincaml_util.Reverse_graph.RevG (DFGraph)) (AD)
+  module D = AD
+
+  type t = D.t
+
+  let analyse ~widen_set ~delay_widen g : AD.t =
+    A.DFGChaoticIter.M.find_opt (0, Entry)
+      (let result =
+         A.analyse (0, Return)
+           ~init:(AD.init (fst g))
+           ~widen_set ~delay_widen
+           (Lazy.force (snd g))
+       in
+       let narrow =
+         N.narrow (0, Return) ~result ~widen_set ~delay_widen
+           (Lazy.force (snd g))
+       in
+       narrow)
+    |> Option.get_exn_or "error: return not reachable from entry"
+
+  let flow_insensitive p =
+    let widen =
+      SimpleSolver.fixpoint_fwd ~initial:(AD.init p)
+        ~transfer:A.Domain.analyze_vert_intra p
+    in
+    SimpleSolver.fixpoint_fwd ~initial:widen
+      ~transfer:N.Domain.analyze_vert_intra p
+end
+
+(** Forwards dataflow analysis over dfg that narrows after widening to a
+    fixpoint *)
+module AnalysisFwdNarrowing (AD : NarrowingDFAnalysis) = struct
+  module A = DataflowAnalysis (DFGraph) (AD)
+  module N = DataflowNarrowing (DFGraph) (AD)
+  module D = AD
+
+  type t = D.t
+
+  let analyse ~widen_set ~delay_widen g : AD.t =
+    A.DFGChaoticIter.M.find_opt (Int.max_int, Return)
+      (let result =
+         A.analyse (0, Entry)
+           ~init:(AD.init (fst g))
+           ~widen_set ~delay_widen
+           (Lazy.force (snd g))
+       in
+       let narrow =
+         N.narrow (0, Entry) ~result ~widen_set ~delay_widen
+           (Lazy.force (snd g))
+       in
+       narrow)
+    |> Option.get_exn_or "error: return not reachable from entry"
+
+  let flow_insensitive p =
+    let widen =
+      SimpleSolver.fixpoint_fwd ~initial:(AD.init p)
+        ~transfer:A.Domain.analyze_vert_intra p
+    in
+    SimpleSolver.fixpoint_fwd ~initial:widen
+      ~transfer:N.Domain.analyze_vert_intra p
 end
 
 (** Simple way to get started with forwards analysis on def-use graph *)

--- a/lib/analysis/defuse_bool.ml
+++ b/lib/analysis/defuse_bool.ml
@@ -23,6 +23,7 @@ module IsZeroLattice = struct
     | _ -> Top
 
   let widening a b = join a b
+  let narrowing a b = a
 
   let leq a b =
     match (a, b) with

--- a/lib/analysis/intra_analysis.ml
+++ b/lib/analysis/intra_analysis.ml
@@ -126,7 +126,7 @@ let tf_forwards st (read_st : 'a -> Var.t -> 'b) (s : Program.stmt)
        ~f_expr:(BasilExpr.fold_with_type alg)
        s
 
-module MapState (V : Lattice_collections.TopLattice) = struct
+module MapState (V : TopLattice) = struct
   include
     Lattice_collections.LatticeMap
       (struct
@@ -135,6 +135,13 @@ module MapState (V : Lattice_collections.TopLattice) = struct
         let show = name
       end)
       (V)
+end
+
+module NarrowingMapState (V1 : TopNarrowingLattice) = struct
+  include MapState (V1)
+  module V = V1
+
+  let narrowing = bot_binop V.narrowing
 end
 
 module type IntraDomain = sig
@@ -174,7 +181,7 @@ module Forwards (D : IntraDomain) = struct
     |> Option.get_or ~default:A.M.empty
 
   let print_dot fmt p analysis_result =
-    Trace_core.with_span ~__FILE__ ~__LINE__ "dot-priner" @@ fun _ ->
+    Trace_core.with_span ~__FILE__ ~__LINE__ "dot-printer" @@ fun _ ->
     let to_dot graph =
       let r =
        fun v -> Option.get_or ~default:D.bottom (A.M.find_opt v analysis_result)

--- a/lib/analysis/intra_analysis.ml
+++ b/lib/analysis/intra_analysis.ml
@@ -226,7 +226,7 @@ module Backwards (D : IntraDomain) = struct
     |> Option.get_or ~default:A.M.empty
 
   let print_dot fmt p analysis_result =
-    Trace_core.with_span ~__FILE__ ~__LINE__ "dot-priner" @@ fun _ ->
+    Trace_core.with_span ~__FILE__ ~__LINE__ "dot-printer" @@ fun _ ->
     let to_dot graph =
       let r =
        fun v -> Option.get_or ~default:D.bottom (A.M.find_opt v analysis_result)

--- a/lib/analysis/intra_analysis.ml
+++ b/lib/analysis/intra_analysis.ml
@@ -137,13 +137,6 @@ module MapState (V : TopLattice) = struct
       (V)
 end
 
-module NarrowingMapState (V1 : TopNarrowingLattice) = struct
-  include MapState (V1)
-  module V = V1
-
-  let narrowing = bot_binop V.narrowing
-end
-
 module type IntraDomain = sig
   include Domain
 

--- a/lib/analysis/known_bits.ml
+++ b/lib/analysis/known_bits.ml
@@ -65,6 +65,7 @@ module KnownBitsLattice = struct
         tnum value mask
 
   let widening a b = join a b
+  let narrowing a b = a
 end
 
 module KnownBitsOps = struct

--- a/lib/analysis/lattice_collections.ml
+++ b/lib/analysis/lattice_collections.ml
@@ -2,12 +2,6 @@ open Lattice_types
 open Bincaml_util.Common
 open Bincaml_util.Unicode
 
-module type TopLattice = sig
-  include Lattice
-
-  val top : t
-end
-
 module type SetElem = sig
   include Set.OrderedType
 
@@ -80,13 +74,13 @@ module LatticeMap (K : MapKey) (V : TopLattice) = struct
       let top = TopMap KM.empty
       let singleton k v = BotMap (KM.singleton k v)
 
-      let top_vjoin _ x y =
-        let j = V.join x y in
-        if V.equal j V.top then None else Some j
+      let bot_v_op f _ x y =
+        let x = f x y in
+        if V.equal x V.bottom then None else Some x
 
-      let top_vwidening _ x y =
-        let j = V.widening x y in
-        if V.equal j V.top then None else Some j
+      let top_v_op f _ x y =
+        let x = f x y in
+        if V.equal x V.top then None else Some x
 
       let underlying = function TopMap m | BotMap m -> m
 
@@ -152,22 +146,24 @@ module LatticeMap (K : MapKey) (V : TopLattice) = struct
         | TopMap a, TopMap b -> KM.reflexive_equal V.equal a b
         | _ -> false
 
-      let join a b =
+      let bot_binop f a b =
         match (a, b) with
-        | BotMap a, BotMap b -> BotMap (KM.idempotent_union (const V.join) a b)
+        | BotMap a, BotMap b -> BotMap (KM.idempotent_union (const f) a b)
         | BotMap a, TopMap b | TopMap b, BotMap a ->
-            TopMap (KM.difference top_vjoin b a)
+            BotMap (KM.difference (bot_v_op f) b a)
         | TopMap a, TopMap b ->
-            TopMap (KM.idempotent_inter_filter top_vjoin a b)
+            BotMap (KM.idempotent_inter_filter (bot_v_op f) a b)
 
-      let widening a b =
+      let top_binop f a b =
         match (a, b) with
-        | BotMap a, BotMap b ->
-            BotMap (KM.idempotent_union (const V.widening) a b)
+        | BotMap a, BotMap b -> BotMap (KM.idempotent_union (const f) a b)
         | BotMap a, TopMap b | TopMap b, BotMap a ->
-            TopMap (KM.difference top_vwidening b a)
+            TopMap (KM.difference (top_v_op f) b a)
         | TopMap a, TopMap b ->
-            TopMap (KM.idempotent_inter_filter top_vwidening a b)
+            TopMap (KM.idempotent_inter_filter (top_v_op f) a b)
+
+      let join = top_binop V.join
+      let widening = top_binop V.widening
 
       let read k = function
         | BotMap m -> KM.find_opt k m |> Option.get_or ~default:V.bottom
@@ -207,6 +203,7 @@ module LatticeMap (K : MapKey) (V : TopLattice) = struct
       sig
         include StateAbstraction with type val_t = V.t and type key_t = K.t
 
+        val bot_binop : (V.t -> V.t -> V.t) -> t -> t -> t
         val top : t
         val of_list_top : (K.t * V.t) list -> t
         val of_list_bot : (K.t * V.t) list -> t

--- a/lib/analysis/lattice_collections.ml
+++ b/lib/analysis/lattice_collections.ml
@@ -49,6 +49,7 @@ module LatticeSet (T : SetElem) = struct
     | _, Top -> true
 
   let widening = join
+  let narrowing a b = a
 end
 
 module type MapKey = sig
@@ -164,6 +165,7 @@ module LatticeMap (K : MapKey) (V : TopLattice) = struct
 
       let join = top_binop V.join
       let widening = top_binop V.widening
+      let narrowing = bot_binop V.narrowing
 
       let read k = function
         | BotMap m -> KM.find_opt k m |> Option.get_or ~default:V.bottom
@@ -203,7 +205,6 @@ module LatticeMap (K : MapKey) (V : TopLattice) = struct
       sig
         include StateAbstraction with type val_t = V.t and type key_t = K.t
 
-        val bot_binop : (V.t -> V.t -> V.t) -> t -> t -> t
         val top : t
         val of_list_top : (K.t * V.t) list -> t
         val of_list_bot : (K.t * V.t) list -> t

--- a/lib/analysis/lattice_types.ml
+++ b/lib/analysis/lattice_types.ml
@@ -13,11 +13,6 @@ module type Lattice = sig
   val equal : t -> t -> bool
   val leq : t -> t -> bool
   val widening : t -> t -> t
-end
-
-module type NarrowingOperator = sig
-  type t
-
   val narrowing : t -> t -> t
 end
 
@@ -27,19 +22,8 @@ module type TopElement = sig
   val top : t
 end
 
-module type NarrowingLattice = sig
-  include Lattice
-  include NarrowingOperator with type t := t
-end
-
 module type TopLattice = sig
   include Lattice
-  include TopElement with type t := t
-end
-
-module type TopNarrowingLattice = sig
-  include Lattice
-  include NarrowingOperator with type t := t
   include TopElement with type t := t
 end
 
@@ -117,14 +101,6 @@ module type StateDomain = sig
   val transfer_state : (Var.t -> V.t) -> Program.stmt -> (Var.t * V.t) Iter.t
 end
 
-module type NarrowingStateDomain = sig
-  type val_t
-
-  module V : NarrowingLattice with type t = val_t
-  include StateDomain with type val_t := val_t with module V := V
-  include NarrowingOperator with type t := t
-end
-
 module type Domain = sig
   include Lattice
 
@@ -187,6 +163,7 @@ struct
     | _ -> false
 
   let widening a b = join a b
+  let narrowing a b = a
 end
 
 module LiftLattice (L : Lattice) : Lattice = struct
@@ -194,6 +171,7 @@ module LiftLattice (L : Lattice) : Lattice = struct
 
   let name = L.name ^ ".lift_lattice"
   let widening a b = map2 L.widening a b
+  let narrowing a b = a
 
   let join a b =
     match (a, b) with

--- a/lib/analysis/lattice_types.ml
+++ b/lib/analysis/lattice_types.ml
@@ -15,6 +15,34 @@ module type Lattice = sig
   val widening : t -> t -> t
 end
 
+module type NarrowingOperator = sig
+  type t
+
+  val narrowing : t -> t -> t
+end
+
+module type TopElement = sig
+  type t
+
+  val top : t
+end
+
+module type NarrowingLattice = sig
+  include Lattice
+  include NarrowingOperator with type t := t
+end
+
+module type TopLattice = sig
+  include Lattice
+  include TopElement with type t := t
+end
+
+module type TopNarrowingLattice = sig
+  include Lattice
+  include NarrowingOperator with type t := t
+  include TopElement with type t := t
+end
+
 (** an abstract value providing opertions of basil ir *)
 module type ValueAbstraction = sig
   include Lattice
@@ -87,6 +115,14 @@ module type StateDomain = sig
 
   val init : ?vertex:Procedure.Vert.t Option.t -> Program.proc -> t
   val transfer_state : (Var.t -> V.t) -> Program.stmt -> (Var.t * V.t) Iter.t
+end
+
+module type NarrowingStateDomain = sig
+  type val_t
+
+  module V : NarrowingLattice with type t = val_t
+  include StateDomain with type val_t := val_t with module V := V
+  include NarrowingOperator with type t := t
 end
 
 module type Domain = sig

--- a/lib/analysis/sp.ml
+++ b/lib/analysis/sp.ml
@@ -100,6 +100,7 @@ module Domain (S : FunctionAnnotation) = struct
   let join (a : t) (b : t) : t = BasilExpr.applyintrin ~op:`OR [ a; b ]
   let leq a b = failwith "leq not implemented"
   let widening a b = top
+  let narrowing a b = a
 
   let locals (p : BasilExpr.t) =
     BasilExpr.free_vars p

--- a/lib/analysis/sva.ml
+++ b/lib/analysis/sva.ml
@@ -60,6 +60,7 @@ module IntervalDomain = struct
   let bottom = WrappedIntervalsLattice.bottom
   let leq = WrappedIntervalsLattice.leq
   let widening = WrappedIntervalsLattice.widening
+  let narrowing = WrappedIntervalsLattice.narrowing
   let join = WrappedIntervalsLattice.join
   let top = WrappedIntervalsLattice.Top
   let neg = WrappedIntervalsLatticeOps.neg

--- a/lib/analysis/tnum_wint_reduced_product.ml
+++ b/lib/analysis/tnum_wint_reduced_product.ml
@@ -122,6 +122,9 @@ module TnumWintReducedProductLattice = struct
 
   let widening s t =
     { tnum = KBL.widening s.tnum t.tnum; wint = WIL.widening s.wint t.wint }
+
+  let narrowing s t =
+    { tnum = KBL.narrowing s.tnum t.tnum; wint = WIL.narrowing s.wint t.wint }
 end
 
 module TnumWintValueAbstraction = struct

--- a/lib/analysis/wp_dual.ml
+++ b/lib/analysis/wp_dual.ml
@@ -83,6 +83,7 @@ module Domain (S : FunctionAnnotation) = struct
 
   let join a b = BasilExpr.applyintrin ~op:`OR [ a; b ] |> simplify
   let widening a b = top
+  let narrowing a b = a
   let init ?(vertex = None) proc = bottom
 
   let leq a b =

--- a/lib/analysis/wrapped_intervals.ml
+++ b/lib/analysis/wrapped_intervals.ml
@@ -196,6 +196,9 @@ module WrappedIntervalsLattice = struct
                     (mul al (of_int ~size:width 2))))
           else top
 
+  (* possibly incorrect?! this isn't implemented in crab or described in the paper *)
+  let narrowing a b = match (a, b) with Top, i -> i | _ -> a
+
   let intersect a b =
     match (a, b) with
     | Bot, _ | _, Bot -> []
@@ -768,7 +771,7 @@ module WrappedIntervalsValueAbstractionBasil = struct
 end
 
 module StateAbstraction =
-  Intra_analysis.MapState (WrappedIntervalsValueAbstractionBasil)
+  Intra_analysis.NarrowingMapState (WrappedIntervalsValueAbstractionBasil)
 
 module Eval = Intra_analysis.EvalStmt (WrappedIntervalsValueAbstractionBasil)
 
@@ -865,7 +868,9 @@ module Domain = struct
                        Bitvec.(add (min ~width) (of_int ~size:width 1))
                        (max ~width)
                 else if Bitvec.equal a (max ~width) then Bot
-                else meet s @@ interval a (max ~width))
+                else
+                  meet s
+                  @@ interval (add a @@ of_int ~size:width 1) (max ~width))
       in
       let uineq = ineq umin umax in
       let sineq = ineq smin smax in
@@ -987,9 +992,42 @@ module Domain = struct
         |> fun v -> update lhs v m
 end
 
-module DFGAnalysis = Dataflow_graph.AnalysisFwd (Domain)
+module DFGAnalysis = Dataflow_graph.AnalysisFwdNarrowing (Domain)
 module Analysis = Intra_analysis.Forwards (Domain)
 
 let analyse (p : Lang.Program.proc) =
   Analysis.analyse ~widening_set:Graph.ChaoticIteration.FromWto
     ~widening_delay:50 p
+
+let%expect_test "narrow_loop" =
+  let prog =
+    (Loader.Loadir.ast_of_string
+       {|
+proc @main()  -> () {  }
+
+[
+   block %entry [ var l_1:bv64 := 0x0:bv64; goto (%ret,%loop); ];
+   block %loop ( var l_2:bv64 := phi(%loop -> l_4:bv64, %entry -> l_1:bv64) ) [
+     var l_3:bv64 := l_2:bv64;
+     assert bvsle(l_3:bv64, 0x100:bv64);
+     var l_4:bv64 := bvadd(l_3:bv64, 0x1:bv64);
+     goto (%ret,%loop);
+   ];
+   block %ret (
+     var l_5:bv64 := phi(%loop -> l_4:bv64, %loop -> l_4:bv64, %entry -> l_1:bv64)
+   ) [
+     var l_6:bv64 := l_5:bv64;
+     assert boolnot(bvsle(l_6:bv64, 0x100:bv64));
+     return;
+   ]
+];
+prog entry @main;
+    |})
+      .prog
+  in
+  let proc = Lang.Program.entry_proc_exn prog in
+  let r = DFGAnalysis.flow_insensitive proc in
+  print_endline @@ StateAbstraction.show r;
+  (* l_6->[0x101, 0x101] we infer an exact value! *)
+  [%expect
+    {| (l_1->⟦0x0:bv64, 0x0:bv64⟧, l_4->⟦0x8000000000000032:bv64, 0x101:bv64⟧, l_2->⟦0x8000000000000031:bv64, 0x101:bv64⟧, l_3->⟦0x8000000000000031:bv64, 0x100:bv64⟧, l_5->⟦0x8000000000000032:bv64, 0x101:bv64⟧, l_6->⟦0x101:bv64, 0x101:bv64⟧, _->⊥) |}]

--- a/lib/analysis/wrapped_intervals.ml
+++ b/lib/analysis/wrapped_intervals.ml
@@ -771,7 +771,7 @@ module WrappedIntervalsValueAbstractionBasil = struct
 end
 
 module StateAbstraction =
-  Intra_analysis.NarrowingMapState (WrappedIntervalsValueAbstractionBasil)
+  Intra_analysis.MapState (WrappedIntervalsValueAbstractionBasil)
 
 module Eval = Intra_analysis.EvalStmt (WrappedIntervalsValueAbstractionBasil)
 

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -96,30 +96,14 @@ module PassManager = struct
       invariants = Invariants.needs [ SSA ];
     }
 
-  let demo_ival_wint_cfg =
-    {
-      name = "demo-ivalwint-product-cfg";
-      apply =
-        Proc
-          (fun p ->
-            ignore @@ Analysis.Wrapped_intervals.analyse p;
-            (*Analysis.Wrapped_intervals.Analysis.print_dot
-              (Format.of_chan stdout) p r;*)
-            p);
-      doc =
-        "Runs wrapped interval analysis on control flow graph and prints \
-         results";
-      invariants = Invariants.needs [ SSA ];
-    }
-
   let demo_ival_wint_dfg =
     {
       name = "demo-ivalwint-product-dfg";
       apply =
         Proc
           (fun p ->
-            let _ = Analysis.Wrapped_intervals.DFGAnalysis.flow_insensitive p in
-            (*print_endline @@ Analysis.Wrapped_intervals.StateAbstraction.show r;*)
+            let r = Analysis.Wrapped_intervals.DFGAnalysis.flow_insensitive p in
+            print_endline @@ Analysis.Wrapped_intervals.StateAbstraction.show r;
             p);
       doc =
         "Runs wrapped interval analysis on control flow graph and prints \
@@ -133,12 +117,12 @@ module PassManager = struct
       apply =
         Proc
           (fun p ->
-            let _ =
+            let r =
               Trace_core.with_span ~__FILE__ ~__LINE__ "dfg_flow_sensitive"
               @@ fun _ -> Analysis.Wrapped_intervals.analyse p
             in
-            (*Analysis.Wrapped_intervals.Analysis.print_dot
-              (Format.of_chan stdout) p r;*)
+            Analysis.Wrapped_intervals.Analysis.print_dot
+              (Format.of_chan stdout) p r;
             p);
       invariants = Invariants.needs [ SSA ];
       doc =
@@ -411,7 +395,6 @@ module PassManager = struct
       cleanup_cfg;
       dfg_bool;
       dfg_ival_wint_product;
-      demo_ival_wint_cfg;
       demo_ival_wint_dfg;
       cfg_wrapped_int;
       cfg_tnum_wint_reduced;

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -119,8 +119,7 @@ module PassManager = struct
         Proc
           (fun p ->
             let _ = Analysis.Wrapped_intervals.DFGAnalysis.flow_insensitive p in
-            (*Analysis.Wrapped_intervals.Analysis.print_dot
-              (Format.of_chan stdout) p r;*)
+            (*print_endline @@ Analysis.Wrapped_intervals.StateAbstraction.show r;*)
             p);
       doc =
         "Runs wrapped interval analysis on control flow graph and prints \

--- a/lib/transforms/livevars.ml
+++ b/lib/transforms/livevars.ml
@@ -61,7 +61,7 @@ let print_g res = Viscfg.dot_labels (fun v -> Some (label res v))
 
 let print_live_vars_dot fmt p =
   let r = run p in
-  Trace_core.with_span ~__FILE__ ~__LINE__ "dot-priner" @@ fun _ ->
+  Trace_core.with_span ~__FILE__ ~__LINE__ "dot-printer" @@ fun _ ->
   let (module M : Viscfg.ProcPrinter) =
     Viscfg.dot_labels (fun v -> Some (label r v))
   in

--- a/lib/transforms/may_read_uninit.ml
+++ b/lib/transforms/may_read_uninit.ml
@@ -35,6 +35,7 @@ module ReadUninit = struct
   let show v = match v with ReadUninit -> "RU" | Bot -> "bot" | Write -> "W"
   let pretty v = Containers_pp.text (show v)
   let widening = join
+  let narrowing a b = a
   let bottom = Bot
   let top = ReadUninit
   let analyze (e : Lang.Procedure.G.edge) d = d


### PR DESCRIPTION
Adds support for abstract domains with a narrowing operator. This is done by running the absint solver twice, the first iteration widening and the second iteration replacing the widening function with the narrowing function (this is how narrowing is presented in Mine's book).

This involved some moving around of a couple of things and having duplicated lattice signatures, which isn't very nice. The alternative is to have every abstract domain have a narrowing operator, which is possible (a default implementation is `a narrow b = a`) but I wasn't sure if this was an ideal solution and would like to know what others think.