### PR TITLE
Aslp make ITE of PC assignments

### DIFF
--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -15,12 +15,15 @@ let ensure_aslp_globals_exist prog = 9
 (** Requires and ensures that the IBI is in the "reset" state. *)
 let lift_opcode (module I : Bincaml_ibi.IBI) ~address opcode =
   Fun.protect ~finally:I.reset_ir (fun () ->
+      I.bincaml_set_address address;
       OfflineASL_pc.Offline.f_A64_decoder (module I) opcode address;
       I.get_ir ())
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
-let lift_empty (module I : Bincaml_ibi.IBI) () =
-  Fun.protect ~finally:I.reset_ir (fun () -> I.get_ir ())
+let lift_empty (module I : Bincaml_ibi.IBI) ~address () =
+  Fun.protect ~finally:I.reset_ir (fun () ->
+      I.bincaml_set_address address;
+      I.get_ir ())
 
 (** Requires and ensures that the IBI is in the "reset" state. *)
 let lift_code_block (module I : Bincaml_ibi.IBI) ~address opcodes =
@@ -35,4 +38,4 @@ let lift_code_block (module I : Bincaml_ibi.IBI) ~address opcodes =
          | None -> Some lifted
          | Some acc -> Some (Aslp_state.append_aslp_states acc lifted))
        None
-  |> Option.get_lazy (lift_empty (module I))
+  |> Option.get_lazy (lift_empty (module I) ~address)

--- a/lib/transforms/aslp/aslp_lexpr.ml
+++ b/lib/transforms/aslp/aslp_lexpr.ml
@@ -71,3 +71,6 @@ let to_var x =
   let ty = typ x and name = name x and scope = scope x in
   let name = match scope with GlobalVar -> "$" ^ name | _ -> name in
   Var.create ~scope name ty
+
+let pc_var = to_var PC
+let branchtaken_var = to_var BranchTaken

--- a/lib/transforms/aslp/aslp_state.ml
+++ b/lib/transforms/aslp/aslp_state.ml
@@ -32,6 +32,8 @@ type aslp_block = {
     assume statement. *)
 
 type aslp_diamond = {
+  address : Bitvec.t;
+      (** Byte address of the instruction described by this diamond. *)
   blocks : aslp_block StringMap.t;
       [@printer StringMap.pp CCString.pp pp_aslp_block]
   entry : string;
@@ -83,7 +85,7 @@ let empty_block () =
 
 let empty_aslp_state ~entry () =
   let blocks = StringMap.singleton entry (empty_block ()) in
-  { blocks; entry; exit = entry }
+  { blocks; entry; exit = entry; address = Bitvec.zero ~size:64 }
 
 (** Constructs a new empty {!lifter_state}.
 
@@ -206,14 +208,15 @@ let append_aslp_states first second =
 
 (** Ensures that the given block ID has a PC assignment. If it already
     {!has_pc_assign}, no changes are made. *)
-let ensure_pc_assigned ~name =
-  modify_block ~name ~f:(function
+let ensure_pc_assigned ~name state =
+  let address = state.address in
+  state
+  |> modify_block ~name ~f:(function
     | { has_pc_assign = false } as block ->
         let pc = Aslp_lexpr.to_var PC
         and branchtaken = Aslp_lexpr.to_var BranchTaken in
         let incremented =
-          Expr.BasilExpr.(
-            applyintrin ~op:`BVADD [ rvar pc; bv_of_int ~size:32 4 ])
+          Expr.BasilExpr.bvconst Bitvec.(add address (of_int ~size:64 4))
         and boolfalse = Expr.BasilExpr.boolconst false in
         let al = [ (branchtaken, boolfalse); (pc, incremented) ] in
         block

--- a/lib/transforms/aslp/aslp_state.ml
+++ b/lib/transforms/aslp/aslp_state.ml
@@ -22,9 +22,9 @@ type aslp_block = {
       [@printer Format.map CCVector.to_list (pp_list_for_printing pp_stmt)]
   succs : StringSet.t;
       [@printer Format.map StringSet.to_list (pp_list_for_printing String.pp)]
-  has_pc_assign : bool;
-      (** Whether, upon reaching the end of this block, it is guaranteed that
-          [PC] will have been assigned to on all control-flow paths. *)
+  pc_assign : Expr.BasilExpr.t option;
+      (** The unique assignment to [PC] which is in effect at the end of this
+          block, if [PC] has been assigned. *)
 }
 [@@deriving show]
 (** An ASLp lifter block is a list of statements followed by a non-deterministic
@@ -81,7 +81,7 @@ type lifter_state = {
 
 let empty_block () =
   let stmts = CCVector.create () and succs = StringSet.empty in
-  { assume = None; stmts; succs; has_pc_assign = false }
+  { assume = None; stmts; succs; pc_assign = None }
 
 let empty_aslp_state ~entry () =
   let blocks = StringMap.singleton entry (empty_block ()) in
@@ -139,26 +139,26 @@ let modify_block aslp_state ~name ~f =
 
 (** Appends the given statement to the given block.
 
-    Sets {!has_pc_assign} if the statement is an assignment to {!Aslp_lexpr.PC}.
-    It is assumed that [PC] is assigned at most once on any straight-line path.
+    Sets {!pc_assign} if the statement is an assignment to {!Aslp_lexpr.PC}. It
+    is assumed that [PC] is assigned at most once on any straight-line path.
     Raises an exception if the statement is an assignment to [PC] and
-    {!has_pc_assign} is already set. *)
+    {!pc_assign} is already set. *)
 let add_stmt_to_block blk ~stmt =
-  let has_pc_assign =
+  let pc_assign =
     match stmt with
     | Stmt.Instr_Assign { al = assigns; _ } ->
-        assigns |> List.map fst |> List.mem ~eq:Var.equal Aslp_lexpr.(to_var PC)
-    | _ -> false
+        assigns |> List.Assoc.get ~eq:Var.equal Aslp_lexpr.(to_var PC)
+    | _ -> None
   in
-  match (has_pc_assign, blk.has_pc_assign) with
-  | true, true ->
+  match (pc_assign, blk.pc_assign) with
+  | Some _, Some _ ->
       failwith
-        "add_stmt_to_block: attempt to add PC assignment but has_pc_assign is \
+        "add_stmt_to_block: attempt to add PC assignment but pc_assign is \
          already set"
-  | true, false ->
+  | Some _, None ->
       CCVector.push blk.stmts stmt;
-      { blk with has_pc_assign }
-  | false, _ ->
+      { blk with pc_assign }
+  | None, _ ->
       CCVector.push blk.stmts stmt;
       blk
 
@@ -170,20 +170,20 @@ let add_stmt_to_active stmt (lifter_state : lifter_state) =
   { lifter_state with diamond }
 
 (** Adds a new goto edge from [source] to [target]. If [source] was the exit
-    block, sets {!exit} to be [target]. If [source] {!has_pc_assign}, this is
+    block, sets {!exit} to be [target]. If [source] {!pc_assign}, this is
     propagated to [target]. *)
 let add_goto aslp_state ~source ~target =
   let exit =
     if String.equal source aslp_state.exit then target else aslp_state.exit
   in
-  let src_has_pc_assign =
-    aslp_state |> get_block ~name:source |> fun x -> x.has_pc_assign
+  let src_pc_assign =
+    aslp_state |> get_block ~name:source |> fun x -> x.pc_assign
   in
   aslp_state
   |> modify_block ~name:source ~f:(fun b ->
       { b with succs = StringSet.add target b.succs })
   |> modify_block ~name:target ~f:(fun b ->
-      if src_has_pc_assign then { b with has_pc_assign = src_has_pc_assign }
+      if Option.is_some src_pc_assign then { b with pc_assign = src_pc_assign }
       else b)
   |> fun s -> { s with exit }
 
@@ -207,27 +207,28 @@ let append_aslp_states first second =
 (** {1 Program counter functions} *)
 
 (** Ensures that the given block ID has a PC assignment. If it already
-    {!has_pc_assign}, no changes are made. *)
+    {!pc_assign}, no changes are made. *)
 let ensure_pc_assigned ~name state =
   let address = state.address in
   state
   |> modify_block ~name ~f:(function
-    | { has_pc_assign = false } as block ->
-        let pc = Aslp_lexpr.to_var PC
-        and branchtaken = Aslp_lexpr.to_var BranchTaken in
+    | { pc_assign = None; _ } as block ->
         let incremented =
           Expr.BasilExpr.bvconst Bitvec.(add address (of_int ~size:64 4))
         and boolfalse = Expr.BasilExpr.boolconst false in
-        let al = [ (branchtaken, boolfalse); (pc, incremented) ] in
+
+        let al =
+          Aslp_lexpr.[ (branchtaken_var, boolfalse); (pc_var, incremented) ]
+        in
         block
         |> add_stmt_to_block
              ~stmt:(Stmt.Instr_Assign { attrib = Attrib.empty; al })
     | block -> block)
 
-(** Ensures that the left and right blocks agree on their {!has_pc_assign}
-    property. If [PC] is assigned in only one of the blocks, a default increment
-    statement will be added to the other block and {!has_pc_assign} will be
-    propagated to [join]. Otherwise, nothing changes.
+(** Ensures that the left and right blocks agree on their {!pc_assign} property.
+    If [PC] is assigned in only one of the blocks, a default increment statement
+    will be added to the other block and {!pc_assign} will be propagated to
+    [join]. Otherwise, nothing changes.
 
     This function should be called with blocks in this structure:
     {v
@@ -241,19 +242,30 @@ let ensure_pc_assigned ~name state =
     This is used to maintain the invariant that at every control flow point, the
     [PC] variable is either assigned on all paths or assigned on no paths (from
     the beginning of the instruction). *)
-let ensure_pc_consistency state ~left ~right ~join =
-  let has_pc_assign, state =
-    match
-      ( (get_block state ~name:left).has_pc_assign,
-        (get_block state ~name:right).has_pc_assign )
-    with
-    | true, false -> (true, state |> ensure_pc_assigned ~name:right)
-    | false, true -> (true, state |> ensure_pc_assigned ~name:left)
-    | _ -> (false, state)
+let ensure_pc_consistency state ~left:lname ~right:rname ~join =
+  let left = get_block state ~name:lname
+  and right = get_block state ~name:rname in
+  let left, right, state =
+    match (left.pc_assign, right.pc_assign) with
+    | Some _, None ->
+        let state = state |> ensure_pc_assigned ~name:rname in
+        (left, get_block state ~name:rname, state)
+    | None, Some _ ->
+        let state = state |> ensure_pc_assigned ~name:lname in
+        (get_block state ~name:lname, right, state)
+    | _ -> (left, right, state)
   in
-  if has_pc_assign then
-    state |> modify_block ~name:join ~f:(fun b -> { b with has_pc_assign })
-  else state
+  match (left, right) with
+  | { pc_assign = None }, { pc_assign = None } -> state
+  | { pc_assign = Some lpc; assume = lassume }, { pc_assign = Some rpc } ->
+      let lassume =
+        Option.get_exn_or
+          "invariant violation: branch expected to have assume set" lassume
+      in
+      let ite = Expr.BasilExpr.(ifthenelse lassume lpc rpc) in
+      state
+      |> modify_block ~name:join ~f:(fun b -> { b with pc_assign = Some ite })
+  | _ -> failwith "invariant violation: pcs should agree at this point"
 
 (** {1 Formatters} *)
 

--- a/lib/transforms/aslp/bincaml_ibi.ml
+++ b/lib/transforms/aslp/bincaml_ibi.ml
@@ -8,6 +8,8 @@ include Bincaml_ibi_make
     {!Lang.Common.Bitvec.t} and the output type as {!Aslp_state.aslp_diamond}
     but leaving other types opaque. *)
 module type IBI = sig
+  val bincaml_set_address : Lang.Common.Bitvec.t -> unit
+
   include
     OfflineASL_pc.Instruction_building_interface.IBI
       with type bitvector = Lang.Common.Bitvec.t

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -25,8 +25,11 @@ struct
 
   (** {2 Bincaml-specific utility functions} *)
 
-  (** Emits the given Bincaml statement. *)
+  let bincaml_set_address address =
+    let diamond = { !S.bincaml_lifter_state.diamond with address } in
+    S.bincaml_lifter_state := { !S.bincaml_lifter_state with diamond }
 
+  (** Emits the given Bincaml statement. *)
   let bincaml_emit stmt =
     S.bincaml_lifter_state :=
       !S.bincaml_lifter_state |> Aslp_state.add_stmt_to_active stmt
@@ -50,7 +53,7 @@ struct
 
   let get_ir () =
     let diamond = !S.bincaml_lifter_state.diamond in
-    Aslp_state.ensure_pc_assigned ~name:diamond.exit diamond
+    diamond |> Aslp_state.ensure_pc_assigned ~name:diamond.exit
 
   let bigint_of_string : string -> bigint = Z.of_string_base 10
   let bigint_of_int : int -> bigint = Z.of_int
@@ -227,10 +230,8 @@ struct
     let active, diamond =
       match b with
       | `T x | `F x -> (x, diamond)
-      | `M (m, (t, f)) ->
-          ( m,
-            diamond |> Aslp_state.ensure_pc_consistency ~left:t ~right:f ~join:m
-          )
+      | `M (join, (left, right)) ->
+          (join, diamond |> Aslp_state.ensure_pc_consistency ~left ~right ~join)
     in
     S.bincaml_lifter_state := { !S.bincaml_lifter_state with active; diamond }
 

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -16,7 +16,7 @@ let%expect_test "lift empty" =
       blocks = "block_0"
       -> { Aslp_state.assume = None;
            stmts = [(var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
-           succs = []; has_pc_assign = true };
+           succs = []; pc_assign = (Some 0x2004:bv64) };
       entry = "block_0"; exit = "block_0" }
     |}]
 
@@ -39,7 +39,7 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
            [var var_0:bv64 := $R2; var var_1:bv64 := $R3;
              $R1:bv64 := bvadd(var_0:bv64, bvshl(var_1:bv64, 0x4:bv12));
              (var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
-           succs = []; has_pc_assign = true };
+           succs = []; pc_assign = (Some 0x2004:bv64) };
       entry = "block_0"; exit = "block_0" }
     |}]
 
@@ -61,13 +61,13 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
            stmts =
            [$R1:bv64 := 0xabcd:bv64;
              (var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
-           succs = ["block_1"]; has_pc_assign = true },
+           succs = ["block_1"]; pc_assign = (Some 0x2004:bv64) },
       "block_1"
       -> { Aslp_state.assume = None;
            stmts =
            [$R1:bv64 := 0xabcd:bv64;
              (var BranchTaken:bool := false, $PC:bv64 := 0x2008:bv64)];
-           succs = []; has_pc_assign = true };
+           succs = []; pc_assign = (Some 0x2004:bv64) };
       entry = "block_0"; exit = "block_1" }
     |}]
 
@@ -86,18 +86,19 @@ let%expect_test "lift: b.eq #1024" =
     { Aslp_state.address = 0x2000:bv64;
       blocks = "block_0"
       -> { Aslp_state.assume = None; stmts = []; succs = ["block_1"; "block_2"];
-           has_pc_assign = false },
+           pc_assign = None },
       "block_1"
       -> { Aslp_state.assume = (Some eq($PSTATE_Z, 0x1:bv1));
            stmts = [var BranchTaken:bool := true; $PC:bv64 := 0x2400:bv64];
-           succs = ["block_3"]; has_pc_assign = true },
+           succs = ["block_3"]; pc_assign = (Some 0x2400:bv64) },
       "block_2"
       -> { Aslp_state.assume = (Some boolnot(eq($PSTATE_Z, 0x1:bv1)));
            stmts = [(var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
-           succs = ["block_3"]; has_pc_assign = true },
+           succs = ["block_3"]; pc_assign = (Some 0x2004:bv64) },
       "block_3"
-      -> { Aslp_state.assume = None; stmts = []; succs = []; has_pc_assign = true
-           };
+      -> { Aslp_state.assume = None; stmts = []; succs = [];
+           pc_assign =
+           (Some if eq($PSTATE_Z, 0x1:bv1) then 0x2400:bv64 else 0x2004:bv64) };
       entry = "block_0"; exit = "block_3" }
     |}]
 

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -6,15 +6,16 @@ let%expect_test "lift empty" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
   in
   let x =
-    lift_code_block (module I) ~address:(Bitvec.zero ~size:64) @@ Iter.empty
+    lift_code_block (module I) ~address:(Bitvec.of_int ~size:64 0x2000)
+    @@ Iter.empty
   in
   print_endline @@ Aslp_state.show_aslp_diamond x;
   [%expect
     {|
-    { Aslp_state.blocks = "block_0"
+    { Aslp_state.address = 0x2000:bv64;
+      blocks = "block_0"
       -> { Aslp_state.assume = None;
-           stmts =
-           [(var BranchTaken:bool := false, $PC:bv64 := bvadd($PC, 0x4:bv32))];
+           stmts = [(var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
            succs = []; has_pc_assign = true };
       entry = "block_0"; exit = "block_0" }
     |}]
@@ -25,18 +26,19 @@ let%expect_test "lift: add x1, x2, x3, lsl #4" =
   let x =
     lift_opcode
       (module I)
-      ~address:(Bitvec.zero ~size:64)
+      ~address:(Bitvec.of_int ~size:64 0x2000)
       (Bitvec.of_string "0x8b031041:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_diamond x;
   [%expect
     {|
-    { Aslp_state.blocks = "block_0"
+    { Aslp_state.address = 0x2000:bv64;
+      blocks = "block_0"
       -> { Aslp_state.assume = None;
            stmts =
            [var var_0:bv64 := $R2; var var_1:bv64 := $R3;
              $R1:bv64 := bvadd(var_0:bv64, bvshl(var_1:bv64, 0x4:bv12));
-             (var BranchTaken:bool := false, $PC:bv64 := bvadd($PC, 0x4:bv32))];
+             (var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
            succs = []; has_pc_assign = true };
       entry = "block_0"; exit = "block_0" }
     |}]
@@ -45,7 +47,7 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
   in
   let x =
-    lift_code_block (module I) ~address:(Bitvec.zero ~size:64)
+    lift_code_block (module I) ~address:(Bitvec.of_int ~size:64 0x2000)
     @@ Iter.doubleton
          (Bitvec.of_string "0xd29579a1:bv32")
          (Bitvec.of_string "0xd29579a1:bv32")
@@ -53,17 +55,18 @@ let%expect_test "lift 2x: mov x1, #0xabcd" =
   print_endline @@ Aslp_state.show_aslp_diamond x;
   [%expect
     {|
-    { Aslp_state.blocks = "block_0"
+    { Aslp_state.address = 0x2000:bv64;
+      blocks = "block_0"
       -> { Aslp_state.assume = None;
            stmts =
            [$R1:bv64 := 0xabcd:bv64;
-             (var BranchTaken:bool := false, $PC:bv64 := bvadd($PC, 0x4:bv32))];
+             (var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
            succs = ["block_1"]; has_pc_assign = true },
       "block_1"
       -> { Aslp_state.assume = None;
            stmts =
            [$R1:bv64 := 0xabcd:bv64;
-             (var BranchTaken:bool := false, $PC:bv64 := bvadd($PC, 0x4:bv32))];
+             (var BranchTaken:bool := false, $PC:bv64 := 0x2008:bv64)];
            succs = []; has_pc_assign = true };
       entry = "block_0"; exit = "block_1" }
     |}]
@@ -74,23 +77,23 @@ let%expect_test "lift: b.eq #1024" =
   let x =
     lift_opcode
       (module I)
-      ~address:(Bitvec.zero ~size:64)
+      ~address:(Bitvec.of_int ~size:64 0x2000)
       (Bitvec.of_string "0x54002000:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_diamond x;
   [%expect
     {|
-    { Aslp_state.blocks = "block_0"
+    { Aslp_state.address = 0x2000:bv64;
+      blocks = "block_0"
       -> { Aslp_state.assume = None; stmts = []; succs = ["block_1"; "block_2"];
            has_pc_assign = false },
       "block_1"
       -> { Aslp_state.assume = (Some eq($PSTATE_Z, 0x1:bv1));
-           stmts = [var BranchTaken:bool := true; $PC:bv64 := 0x400:bv64];
+           stmts = [var BranchTaken:bool := true; $PC:bv64 := 0x2400:bv64];
            succs = ["block_3"]; has_pc_assign = true },
       "block_2"
       -> { Aslp_state.assume = (Some boolnot(eq($PSTATE_Z, 0x1:bv1)));
-           stmts =
-           [(var BranchTaken:bool := false, $PC:bv64 := bvadd($PC, 0x4:bv32))];
+           stmts = [(var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
            succs = ["block_3"]; has_pc_assign = true },
       "block_3"
       -> { Aslp_state.assume = None; stmts = []; succs = []; has_pc_assign = true


### PR DESCRIPTION
this also injects the hardcoded address rather than emitting a `PC+=4` in the default case. it's a bit of awful mutation to pass this into the IBI because it's not naturally in the IBI signature but it's porobably chill.

```ocaml
let%expect_test "lift: b.eq #1024" =
  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
  in
  let x =
    lift_opcode
      (module I)
      ~address:(Bitvec.of_int ~size:64 0x2000)
      (Bitvec.of_string "0x54002000:bv32")
  in
  print_endline @@ Aslp_state.show_aslp_diamond x;
  [%expect
    {|
    { Aslp_state.address = 0x2000:bv64;
      blocks = "block_0"
      -> { Aslp_state.assume = None; stmts = []; succs = ["block_1"; "block_2"];
           pc_assign = None },
      "block_1"
      -> { Aslp_state.assume = (Some eq($PSTATE_Z, 0x1:bv1));
           stmts = [var BranchTaken:bool := true; $PC:bv64 := 0x2400:bv64];
           succs = ["block_3"]; pc_assign = (Some 0x2400:bv64) },
      "block_2"
      -> { Aslp_state.assume = (Some boolnot(eq($PSTATE_Z, 0x1:bv1)));
           stmts = [(var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
           succs = ["block_3"]; pc_assign = (Some 0x2004:bv64) },
      "block_3"
      -> { Aslp_state.assume = None; stmts = []; succs = [];
           pc_assign =
           (Some if eq($PSTATE_Z, 0x1:bv1) then 0x2400:bv64 else 0x2004:bv64) };
      entry = "block_0"; exit = "block_3" }
    |}]
```