### PR TITLE
Add assertions and failing test cases for Aslp context switch

### DIFF
--- a/lib/transforms/aslp/bincaml_ibi.ml
+++ b/lib/transforms/aslp/bincaml_ibi.ml
@@ -9,6 +9,7 @@ include Bincaml_ibi_make
     but leaving other types opaque. *)
 module type IBI = sig
   val bincaml_set_address : Lang.Common.Bitvec.t -> unit
+  val bincaml_internal_emit : Aslp_state.stmt -> unit
 
   include
     OfflineASL_pc.Instruction_building_interface.IBI

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -29,7 +29,7 @@ struct
     !bincaml_lifter_state.address |> Option.get_exn_or err
 
   (** Emits the given Bincaml statement. *)
-  let bincaml_emit stmt =
+  let bincaml_internal_emit stmt =
     bincaml_lifter_state :=
       !bincaml_lifter_state |> Aslp_state.add_stmt_to_active stmt
 
@@ -53,6 +53,8 @@ struct
   let get_ir () =
     let diamond = !bincaml_lifter_state.diamond
     and address = bincaml_get_address () in
+    if not (List.is_empty (snd diamond)) then
+      failwith "invariant violation: context switches did not return to merge";
     diamond |> Aslp_state.ensure_pc_assigned ~address |> Diamond.of_zipper
 
   let bigint_of_string : string -> bigint = Z.of_string_base 10
@@ -231,7 +233,9 @@ struct
   let f_merge_branch : branch * branch * branch -> branch = fun (t, f, m) -> m
 
   let f_gen_assert : expr -> unit =
-   fun e -> bincaml_emit (Stmt.Instr_Assert { attrib = Attrib.empty; body = e })
+   fun e ->
+    bincaml_internal_emit
+      (Stmt.Instr_Assert { attrib = Attrib.empty; body = e })
 
   let f_gen_bit_lit : bigint -> bitvector -> expr =
    fun _ bv -> Expr.BasilExpr.const (`Bitvector bv)
@@ -249,7 +253,7 @@ struct
 
   let f_gen_store : lexpr -> expr -> unit =
    fun lhs rhs ->
-    bincaml_emit
+    bincaml_internal_emit
       (Stmt.Instr_Assign
          { attrib = Attrib.empty; al = [ (Aslp_lexpr.to_var lhs, rhs) ] })
 

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -5,6 +5,7 @@ open Transforms.Aslp
 let id_gen = lazy (ID.make_gen ())
 
 let make_call name =
+  Printf.printf "make_call: %s\n" name;
   Stmt.Instr_Call
     {
       attrib = Attrib.empty;
@@ -13,10 +14,18 @@ let make_call name =
       procid = (Lazy.force_val id_gen).fresh ~name ();
     }
 
+let guard f =
+  CCResult.pp CCFormat.unit Format.stdout
+    (CCResult.guard_str (fun () -> ignore (f ())))
+
+let guard_get_ir f =
+  print_endline @@ CCResult.retract
+  @@ CCResult.guard_str (fun () -> Aslp_state.show_aslp_diamond (f ()))
+
 let%expect_test "nested diamonds" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
   in
-  I.bincaml_set_address (Bitvec.of_int ~size:64 0xbadbadbad000);
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
   let branch1 = I.f_gen_branch (I.f_gen_bool_lit true) in
   I.bincaml_internal_emit (make_call "entry");
 
@@ -42,9 +51,16 @@ let%expect_test "nested diamonds" =
   I.f_switch_context (I.f_merge_branch branch1);
   I.bincaml_internal_emit (make_call "m");
 
-  print_endline @@ Aslp_state.show_aslp_diamond @@ I.get_ir ();
+  guard_get_ir I.get_ir;
   [%expect
     {|
+    make_call: entry
+    make_call: t
+    make_call: f
+    make_call: ft
+    make_call: ff
+    make_call: fm
+    make_call: m
     Diamond {
       pred =
       (Leaf
@@ -68,15 +84,199 @@ let%expect_test "nested diamonds" =
         (Leaf
            { Aslp_state.assume = boolnot(false);
              stmts =
-             [call ff();
-               (var BranchTaken:bool := false, $PC:bv64 := 0xbadbadbad004:bv64)];
-             pc_assign = (Some 0xbadbadbad004:bv64) });
+             [call ff(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+             pc_assign = (Some 0xfb3:bv64) });
         value =
         { Aslp_state.assume = true; stmts = [call fm()];
-          pc_assign = (Some if false then 0xbbb:bv64 else 0xbadbadbad004:bv64) }};
+          pc_assign = (Some if false then 0xbbb:bv64 else 0xfb3:bv64) }};
       value =
       { Aslp_state.assume = true; stmts = [call m()];
         pc_assign =
-        (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xbadbadbad004:bv64)
+        (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xfb3:bv64)
         }}
+    |}]
+
+let%expect_test "sequential diamonds" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  ( guard @@ fun () ->
+    I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+    let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
+    I.bincaml_internal_emit (make_call "entry");
+
+    I.f_switch_context (I.f_true_branch b1);
+    I.bincaml_internal_emit (make_call "b1_t");
+    I.f_switch_context (I.f_merge_branch b1);
+
+    let b2 = I.f_gen_branch (I.f_gen_bool_lit true) in
+    I.f_switch_context (I.f_true_branch b2);
+    I.bincaml_internal_emit (make_call "b2_t");
+    I.f_switch_context (I.f_merge_branch b2);
+
+    I.bincaml_internal_emit (make_call "exit");
+
+    guard_get_ir I.get_ir );
+  [%expect
+    {|
+    make_call: entry
+    make_call: b1_t
+    make_call: b2_t
+    make_call: exit
+    Diamond {
+      pred =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call entry_1()]; pc_assign = None
+             });
+        left =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call b1_t()]; pc_assign = None });
+        right =
+        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      left =
+      (Leaf { Aslp_state.assume = true; stmts = [call b2_t()]; pc_assign = None });
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call exit(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
+    ok(())
+    |}]
+
+let%expect_test "skipped merge context when going to outer merge" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+  let outer = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "entry");
+
+  I.f_switch_context (I.f_true_branch outer);
+  I.bincaml_internal_emit (make_call "t");
+
+  let inner = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.f_switch_context (I.f_true_branch inner);
+  I.bincaml_internal_emit (make_call "tt");
+  I.f_switch_context (I.f_false_branch inner);
+  I.bincaml_internal_emit (make_call "tf");
+
+  (* context switch skipped: *)
+  (* I.f_switch_context (I.f_merge_branch inner); *)
+  I.f_switch_context (I.f_merge_branch outer);
+  I.bincaml_internal_emit (make_call "m_outer");
+
+  guard_get_ir I.get_ir;
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: t
+    make_call: tt
+    make_call: tf
+    make_call: m_outer
+    Failure("invariant violation: context switches did not return to merge")
+    |}]
+
+let%expect_test "skipped merge context when going to outer branch" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+  let outer = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "entry");
+
+  I.f_switch_context (I.f_true_branch outer);
+  I.bincaml_internal_emit (make_call "t");
+
+  let inner = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.f_switch_context (I.f_true_branch inner);
+  I.bincaml_internal_emit (make_call "tt");
+  I.f_switch_context (I.f_false_branch inner);
+  I.bincaml_internal_emit (make_call "tf");
+
+  (* context switch skipped: *)
+  (* I.f_switch_context (I.f_merge_branch inner); *)
+  I.f_switch_context (I.f_false_branch outer);
+  I.bincaml_internal_emit (make_call "f");
+
+  I.f_switch_context (I.f_merge_branch outer);
+  I.bincaml_internal_emit (make_call "m_outer");
+
+  guard_get_ir I.get_ir;
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: t
+    make_call: tt
+    make_call: tf
+    make_call: f
+    make_call: m_outer
+    Failure("invariant violation: context switches did not return to merge")
+    |}]
+
+let%expect_test
+    "pathological: referencing old branch with intervening gen_branch" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+  let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "entry");
+
+  let _ = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "still_in_entry");
+
+  I.f_switch_context (I.f_true_branch b1);
+  I.bincaml_internal_emit (make_call "true_of_first_branch");
+
+  I.f_switch_context (I.f_merge_branch b1);
+  I.bincaml_internal_emit (make_call "end");
+
+  guard_get_ir I.get_ir;
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: still_in_entry
+    make_call: true_of_first_branch
+    make_call: end
+    Failure("invariant violation: context switches did not return to merge")
+    |}]
+
+let%expect_test
+    "pathological: sequential diamonds, then going back into the first one" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  ( guard @@ fun () ->
+    begin
+      I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+      let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
+      I.bincaml_internal_emit (make_call "entry");
+
+      I.f_switch_context (I.f_true_branch b1);
+      I.bincaml_internal_emit (make_call "b1_t");
+      I.f_switch_context (I.f_merge_branch b1);
+
+      let b2 = I.f_gen_branch (I.f_gen_bool_lit true) in
+      I.f_switch_context (I.f_true_branch b2);
+      I.bincaml_internal_emit (make_call "b2_t");
+      I.f_switch_context (I.f_merge_branch b2);
+
+      I.f_switch_context (I.f_true_branch b1);
+      I.bincaml_internal_emit (make_call "b1_t_again");
+
+      I.f_switch_context (I.f_merge_branch b2);
+      I.bincaml_internal_emit (make_call "exit");
+
+      guard_get_ir I.get_ir
+    end );
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: b1_t
+    make_call: b2_t
+    error(Invalid_argument("result is Error _"))
     |}]

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -2,59 +2,80 @@ open Lang
 open Common
 open Transforms.Aslp
 
+let id_gen = lazy (ID.make_gen ())
+
+let make_call name =
+  Stmt.Instr_Call
+    {
+      attrib = Attrib.empty;
+      lhs = StringMap.empty;
+      args = StringMap.empty;
+      procid = (Lazy.force_val id_gen).fresh ~name ();
+    }
+
 let%expect_test "nested diamonds" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
   in
   I.bincaml_set_address (Bitvec.of_int ~size:64 0xbadbadbad000);
   let branch1 = I.f_gen_branch (I.f_gen_bool_lit true) in
-  I.f_gen_assert (I.f_gen_bool_lit true);
+  I.bincaml_internal_emit (make_call "entry");
 
   I.f_switch_context (I.f_true_branch branch1);
+  I.bincaml_internal_emit (make_call "t");
   I.f_gen_store I.v__PC
     (I.f_gen_bit_lit (I.bigint_of_int 64) (Bitvec.of_int ~size:64 0xaaa));
 
   I.f_switch_context (I.f_false_branch branch1);
+  I.bincaml_internal_emit (make_call "f");
   begin
     let branch2 = I.f_gen_branch (I.f_gen_bool_lit false) in
     I.f_switch_context (I.f_true_branch branch2);
+    I.bincaml_internal_emit (make_call "ft");
     I.f_gen_store I.v__PC
       (I.f_gen_bit_lit (I.bigint_of_int 64) (Bitvec.of_int ~size:64 0xbbb));
     I.f_switch_context (I.f_false_branch branch2);
-    I.f_switch_context (I.f_merge_branch branch2)
+    I.bincaml_internal_emit (make_call "ff");
+    I.f_switch_context (I.f_merge_branch branch2);
+    I.bincaml_internal_emit (make_call "fm")
   end;
 
   I.f_switch_context (I.f_merge_branch branch1);
-  I.f_gen_assert (I.f_gen_bool_lit false);
+  I.bincaml_internal_emit (make_call "m");
 
   print_endline @@ Aslp_state.show_aslp_diamond @@ I.get_ir ();
   [%expect
     {|
     Diamond {
       pred =
-      (Leaf { Aslp_state.assume = true; stmts = [assert true]; pc_assign = None });
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call entry()]; pc_assign = None });
       left =
       (Leaf
-         { Aslp_state.assume = true; stmts = [$PC:bv64 := 0xaaa:bv64];
+         { Aslp_state.assume = true; stmts = [call t(); $PC:bv64 := 0xaaa:bv64];
            pc_assign = (Some 0xaaa:bv64) });
       right =
       Diamond {
         pred =
-        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        (Leaf
+           { Aslp_state.assume = boolnot(true); stmts = [call f()];
+             pc_assign = None });
         left =
         (Leaf
-           { Aslp_state.assume = false; stmts = [$PC:bv64 := 0xbbb:bv64];
+           { Aslp_state.assume = false;
+             stmts = [call ft(); $PC:bv64 := 0xbbb:bv64];
              pc_assign = (Some 0xbbb:bv64) });
         right =
         (Leaf
            { Aslp_state.assume = boolnot(false);
              stmts =
-             [(var BranchTaken:bool := false, $PC:bv64 := 0xbadbadbad004:bv64)];
+             [call ff();
+               (var BranchTaken:bool := false, $PC:bv64 := 0xbadbadbad004:bv64)];
              pc_assign = (Some 0xbadbadbad004:bv64) });
         value =
-        { Aslp_state.assume = true; stmts = [];
+        { Aslp_state.assume = true; stmts = [call fm()];
           pc_assign = (Some if false then 0xbbb:bv64 else 0xbadbadbad004:bv64) }};
       value =
-      { Aslp_state.assume = true; stmts = [assert false];
+      { Aslp_state.assume = true; stmts = [call m()];
         pc_assign =
         (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xbadbadbad004:bv64)
         }}


### PR DESCRIPTION
If the context switching is correct, then at the end of lifting one instruction, the position should be at the final (outermost) merge point. 

Re https://github.com/agle/bincaml/pull/193#discussion_r3472106387. That code was from lib/pc/aarch64_vector_arithmetic_unary_extract_sat_simd.ml

What other cases should I add? In offline_opt, it looks like context switches start out properly bracketed and some switches are _removed_. This constrains the possible context switches somewhat https://github.com/UQ-PAC/aslp/blob/92e4fd949402056e16e3747e66922060be57ecc8/libASL/offline_opt.ml#L312

