### PR TITLE
add explicit menhir dependency to capstone to avoid dune differences

### DIFF
--- a/capstone_arm64_disas.opam
+++ b/capstone_arm64_disas.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"
   "ppx_expect"
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -26,9 +26,9 @@
  (name capstone_arm64_disas)
  (synopsis "Disas arm ops with capstone")
  (depends
-   ocaml
-   ppx_expect
-   )
+  (menhir (>= 20180523))
+  ocaml
+  ppx_expect)
 )
 
 (package


### PR DESCRIPTION
this is not great because capstone doesn't need menhir, but i guess recent dune versions insist on adding a menhir dependency (with automatic version constraint) to every package in thr project.

specifying it explicitly avoids different behaviour in different dune versions.