### PR TITLE
Move Aslp IBI control flow into its own module

### DIFF
--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -9,8 +9,9 @@ open Lang
 open Common
 module Aslp_state = Aslp_state
 module Aslp_lexpr = Aslp_lexpr
-module Bincaml_ibi = Bincaml_ibi
 module Diamond = Diamond
+module Diamond_ibi = Diamond_ibi
+module Bincaml_ibi = Bincaml_ibi
 
 let ensure_aslp_globals_exist prog = 9
 

--- a/lib/transforms/aslp/bincaml_ibi.ml
+++ b/lib/transforms/aslp/bincaml_ibi.ml
@@ -1,3 +1,6 @@
+(** Main definition of the IBI, lifting into a structured
+    {!Aslp_state.aslp_diamond}. *)
+
 open Lang
 open Common
 

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -13,7 +13,6 @@ struct
   type expr = Expr.BasilExpr.t
   type lexpr = Aslp_lexpr.t
   type stmt = Aslp_state.stmt
-  type branch = [ `T | `F | `M ]
   type ast = Aslp_state.aslp_diamond
 
   (** {2 Bincaml-specific utility functions} *)
@@ -44,7 +43,38 @@ struct
     in
     Aslp_lexpr.Local (id_name, ty)
 
-  (** {2 Instruction building interface implementation} *)
+  (** {2 Control flow}
+
+      Implemented by {!Diamond_ibi.Make}. *)
+
+  (** @inline *)
+  include Diamond_ibi.Make (struct
+    type nonrec expr = expr
+    type state = Aslp_state.aslp_block
+
+    let diamond_get () = !bincaml_lifter_state.diamond
+
+    let diamond_set diamond =
+      bincaml_lifter_state := { !bincaml_lifter_state with diamond }
+
+    let diamond_make_branch cond =
+      let t = Aslp_state.empty_block ~assume:cond ()
+      and f = Aslp_state.empty_block ~assume:(Expr.BasilExpr.boolnot cond) ()
+      and m = Aslp_state.empty_block_unconditional () in
+      (t, f, m)
+  end)
+
+  let f_switch_context b =
+    f_switch_context b;
+    match b with
+    | `T | `F -> ()
+    | `M ->
+        let address = bincaml_get_address ()
+        and diamond = !bincaml_lifter_state.diamond in
+        let diamond = diamond |> Aslp_state.ensure_pc_consistency ~address in
+        bincaml_lifter_state := { !bincaml_lifter_state with diamond }
+
+  (** {2 IR extraction} *)
 
   let reset_ir () =
     let generator = !bincaml_lifter_state.generator in
@@ -54,6 +84,8 @@ struct
     let diamond = !bincaml_lifter_state.diamond
     and address = bincaml_get_address () in
     diamond |> Aslp_state.ensure_pc_assigned ~address |> Diamond.of_zipper
+
+  (** {2 Instruction building interface implementation} *)
 
   let bigint_of_string : string -> bigint = Z.of_string_base 10
   let bigint_of_int : int -> bigint = Z.of_int
@@ -199,36 +231,6 @@ struct
   let v___BranchTaken : lexpr = BranchTaken
   let v_BTypeNext : lexpr = BTypeNext
   let v___ExclusiveLocal : lexpr = ExclusiveLocal
-
-  let f_gen_branch : expr -> branch * branch * branch =
-   fun cond ->
-    let st = !bincaml_lifter_state and ncond = Expr.BasilExpr.boolnot cond in
-
-    let left = Diamond.empty (Aslp_state.empty_block ~assume:cond ())
-    and right = Diamond.empty (Aslp_state.empty_block ~assume:ncond ())
-    and value = Aslp_state.empty_block_unconditional () in
-
-    let diamond = st.diamond |> Diamond.append_diamond ~left ~right ~value in
-    bincaml_lifter_state := { st with diamond };
-    (`T, `F, `M)
-
-  let f_switch_context : branch -> unit =
-   fun b ->
-    let diamond = !bincaml_lifter_state.diamond
-    and address = bincaml_get_address () in
-    let diamond =
-      match b with
-      | `T -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
-      | `F -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
-      | `M ->
-          diamond |> Diamond.move_out_of |> Result.get_ok
-          |> Aslp_state.ensure_pc_consistency ~address
-    in
-    bincaml_lifter_state := { !bincaml_lifter_state with diamond }
-
-  let f_true_branch : branch * branch * branch -> branch = fun (t, f, m) -> t
-  let f_false_branch : branch * branch * branch -> branch = fun (t, f, m) -> f
-  let f_merge_branch : branch * branch * branch -> branch = fun (t, f, m) -> m
 
   let f_gen_assert : expr -> unit =
    fun e -> bincaml_emit (Stmt.Instr_Assert { attrib = Attrib.empty; body = e })

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -41,10 +41,14 @@ module Make (S : Params) = struct
 
   let f_switch_context : branch -> unit =
    fun b ->
-    (b, S.diamond_get ())
-    |> ( function
-    | `T, diamond -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
-    | `F, diamond -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
-    | `M, diamond -> diamond |> Diamond.move_out_of |> Result.get_ok )
-    |> S.diamond_set
+    let show_branch_error b =
+      "while moving to branch " ^ [%derive.show: [ `T | `F | `M ]] b
+    in
+    S.diamond_get ()
+    |> (match b with
+      | `T -> Diamond.move_adjacent `L
+      | `F -> Diamond.move_adjacent `R
+      | `M -> Diamond.move_out_of)
+    |> Result.map_error (fun _ -> show_branch_error b)
+    |> CCResult.get_or_failwith |> S.diamond_set
 end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -1,0 +1,50 @@
+(** Implements control flow functionality for the IBI by using
+    {!Diamond.diamond_zipper}. *)
+
+(** Necessary parameters to provide IBI control flow functions. *)
+module type Params = sig
+  type expr
+
+  type state
+  (** Type of the state stored inside each control-flow point of the
+      {!Diamond.diamond_zipper}. *)
+
+  val diamond_get : unit -> state Diamond.diamond_zipper
+  val diamond_set : state Diamond.diamond_zipper -> unit
+
+  val diamond_make_branch : expr -> state * state * state
+  (** Should return [(t,f,m)] *)
+end
+
+(** Implements control flow functionality for the IBI by using
+    {!Diamond.diamond_zipper}. See {!module-Diamond} for more details. *)
+module Make (S : Params) = struct
+  type branch = [ `T | `F | `M ]
+  (** Branch switches are identified {b relatively} at the moment.
+
+      TODO: this is wrong in the presence of elided intermediate context
+      switches (and other non-trivial cases)! *)
+
+  let f_true_branch : branch * branch * branch -> branch = fun (t, f, m) -> t
+  let f_false_branch : branch * branch * branch -> branch = fun (t, f, m) -> f
+  let f_merge_branch : branch * branch * branch -> branch = fun (t, f, m) -> m
+
+  let f_gen_branch : S.expr -> branch * branch * branch =
+   fun cond ->
+    let t, f, m = S.diamond_make_branch cond in
+    let t = Diamond.empty t and f = Diamond.empty f in
+
+    S.diamond_get ()
+    |> Diamond.append_diamond ~left:t ~right:f ~value:m
+    |> S.diamond_set;
+    (`T, `F, `M)
+
+  let f_switch_context : branch -> unit =
+   fun b ->
+    (b, S.diamond_get ())
+    |> ( function
+    | `T, diamond -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
+    | `F, diamond -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
+    | `M, diamond -> diamond |> Diamond.move_out_of |> Result.get_ok )
+    |> S.diamond_set
+end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -41,14 +41,12 @@ module Make (S : Params) = struct
 
   let f_switch_context : branch -> unit =
    fun b ->
-    let show_branch_error b =
-      "while moving to branch " ^ [%derive.show: [ `T | `F | `M ]] b
-    in
+    let show_err b = "while moving to branch " ^ [%derive.show: branch] b in
     S.diamond_get ()
     |> (match b with
       | `T -> Diamond.move_adjacent `L
       | `F -> Diamond.move_adjacent `R
       | `M -> Diamond.move_out_of)
-    |> Result.map_error (fun _ -> show_branch_error b)
+    |> Result.map_error (fun _ -> show_err b)
     |> CCResult.get_or_failwith |> S.diamond_set
 end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -41,12 +41,12 @@ module Make (S : Params) = struct
 
   let f_switch_context : branch -> unit =
    fun b ->
-    let show_err b = "while moving to branch " ^ [%derive.show: branch] b in
+    let show b = "when moving to branch" ^ [%derive.show: [ `T | `F | `M ]] b in
     S.diamond_get ()
     |> (match b with
       | `T -> Diamond.move_adjacent `L
       | `F -> Diamond.move_adjacent `R
       | `M -> Diamond.move_out_of)
-    |> Result.map_error (fun _ -> show_err b)
+    |> Result.map_error (fun _ -> show b)
     |> CCResult.get_or_failwith |> S.diamond_set
 end


### PR DESCRIPTION
Moves it into diamond_ibi.ml.

This separates the concerns of expr/stmt IBI and control flow IBI which are fairly separate. The hope is that, eventually, we can provide a generic implementation of the control flow and avoid every IBI having to implement its own almost-identical control flow. But we're a long way from that right now.