### PR TITLE
Fix wrapped interval join soundess bug

### DIFF
--- a/lib/analysis/wrapped_intervals.ml
+++ b/lib/analysis/wrapped_intervals.ml
@@ -150,6 +150,7 @@ module WrappedIntervalsLattice = struct
         (fun acc t ->
           match t with
           | Interval { lower; upper } when ule upper lower -> extend acc t
+          | Top -> extend acc t
           | _ -> acc)
         bottom sorted
     in

--- a/test/analysis/test_wrapped_intervals.ml
+++ b/test/analysis/test_wrapped_intervals.ml
@@ -94,7 +94,8 @@ open struct
     lub [ bottom; top; bottom ] = top;
     lub [ bottom; iv 0 9; top ] = top;
     lub [ iv 0 3; iv 3 5; iv 4 6 ] = iv 0 6;
-    lub [ iv 0 3; iv 6 10; iv 14 15 ] = iv 14 10
+    lub [ iv 0 3; iv 6 10; iv 14 15 ] = iv 14 10;
+    lub [ top; iv 8 15; iv 10 0; iv 0 3 ] = top
 
   let intersect () =
     let ( = ) a b = Alcotest.(check (list ival)) "equal" a b in


### PR DESCRIPTION
it seems that the "if Top or" part of this algorithm was forgotten :(

<img width="877" height="400" alt="image" src="https://github.com/user-attachments/assets/3281f52a-254e-4868-8137-90a8152e790e" />

this was only caught because CI randomly failed after generating a very rare expression that hit a very specific equality edge case in the sdiv logic `when not ((au = smin && bl = neg1) || (al = smin && bu = neg1))` that happened to create a weird join shape. it is worrying to think that other edge cases like this could be lurking in the depths...