### PR TITLE
Implement Aslp context switching using a zipper path skeleton

### DIFF
--- a/capstone_arm64_disas.opam
+++ b/capstone_arm64_disas.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"
   "ppx_expect"
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/lib/transforms/aslp/aslp.ml
+++ b/lib/transforms/aslp/aslp.ml
@@ -9,8 +9,9 @@ open Lang
 open Common
 module Aslp_state = Aslp_state
 module Aslp_lexpr = Aslp_lexpr
-module Bincaml_ibi = Bincaml_ibi
 module Diamond = Diamond
+module Diamond_ibi = Diamond_ibi
+module Bincaml_ibi = Bincaml_ibi
 
 let ensure_aslp_globals_exist prog = 9
 

--- a/lib/transforms/aslp/bincaml_ibi.ml
+++ b/lib/transforms/aslp/bincaml_ibi.ml
@@ -1,3 +1,6 @@
+(** Main definition of the IBI, lifting into a structured
+    {!Aslp_state.aslp_diamond}. *)
+
 open Lang
 open Common
 

--- a/lib/transforms/aslp/bincaml_ibi.ml
+++ b/lib/transforms/aslp/bincaml_ibi.ml
@@ -9,6 +9,7 @@ include Bincaml_ibi_make
     but leaving other types opaque. *)
 module type IBI = sig
   val bincaml_set_address : Lang.Common.Bitvec.t -> unit
+  val bincaml_internal_emit : Aslp_state.stmt -> unit
 
   include
     OfflineASL_pc.Instruction_building_interface.IBI

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -64,7 +64,7 @@ struct
       (t, f, m)
   end)
 
-  let f_switch_context ((_, d, st) as ctx) =
+  let f_switch_context ((_, d, expected) as ctx) =
     f_switch_context ctx;
     let address = bincaml_get_address ()
     and diamond = !bincaml_lifter_state.diamond in
@@ -79,7 +79,7 @@ struct
             diamond)
       |> Diamond.focus
     in
-    if not (CCEqual.physical merge_point.stmts st.Aslp_state.stmts) then
+    if not (CCEqual.physical merge_point.stmts expected.Aslp_state.stmts) then
       failwith
         "invariant violation: context switch did not arrive at expected point"
 

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -64,15 +64,24 @@ struct
       (t, f, m)
   end)
 
-  let f_switch_context b =
-    f_switch_context b;
-    match fst b with
-    | `T | `F -> ()
-    | `M ->
-        let address = bincaml_get_address ()
-        and diamond = !bincaml_lifter_state.diamond in
-        let diamond = diamond |> Aslp_state.ensure_pc_consistency ~address in
-        bincaml_lifter_state := { !bincaml_lifter_state with diamond }
+  let f_switch_context ((_, d, st) as ctx) =
+    f_switch_context ctx;
+    let address = bincaml_get_address ()
+    and diamond = !bincaml_lifter_state.diamond in
+    let merge_point =
+      (match d with
+        | `T | `F -> diamond |> Diamond.move_out_of |> Result.get_ok
+        | `M ->
+            let diamond =
+              diamond |> Aslp_state.ensure_pc_consistency ~address
+            in
+            bincaml_lifter_state := { !bincaml_lifter_state with diamond };
+            diamond)
+      |> Diamond.focus
+    in
+    if not (CCEqual.physical merge_point.stmts st.Aslp_state.stmts) then
+      failwith
+        "invariant violation: context switch did not arrive at expected point"
 
   (** {2 IR extraction} *)
 

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -66,7 +66,7 @@ struct
 
   let f_switch_context b =
     f_switch_context b;
-    match b with
+    match fst b with
     | `T | `F -> ()
     | `M ->
         let address = bincaml_get_address ()

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -13,7 +13,6 @@ struct
   type expr = Expr.BasilExpr.t
   type lexpr = Aslp_lexpr.t
   type stmt = Aslp_state.stmt
-  type branch = [ `T | `F | `M ]
   type ast = Aslp_state.aslp_diamond
 
   (** {2 Bincaml-specific utility functions} *)
@@ -44,7 +43,38 @@ struct
     in
     Aslp_lexpr.Local (id_name, ty)
 
-  (** {2 Instruction building interface implementation} *)
+  (** {2 Control flow}
+
+      Implemented by {!Diamond_ibi.Make}. *)
+
+  (** @inline *)
+  include Diamond_ibi.Make (struct
+    type nonrec expr = expr
+    type state = Aslp_state.aslp_block
+
+    let diamond_get () = !bincaml_lifter_state.diamond
+
+    let diamond_set diamond =
+      bincaml_lifter_state := { !bincaml_lifter_state with diamond }
+
+    let diamond_make_branch cond =
+      let t = Aslp_state.empty_block ~assume:cond ()
+      and f = Aslp_state.empty_block ~assume:(Expr.BasilExpr.boolnot cond) ()
+      and m = Aslp_state.empty_block_unconditional () in
+      (t, f, m)
+  end)
+
+  let f_switch_context b =
+    f_switch_context b;
+    match b with
+    | `T | `F -> ()
+    | `M ->
+        let address = bincaml_get_address ()
+        and diamond = !bincaml_lifter_state.diamond in
+        let diamond = diamond |> Aslp_state.ensure_pc_consistency ~address in
+        bincaml_lifter_state := { !bincaml_lifter_state with diamond }
+
+  (** {2 IR extraction} *)
 
   let reset_ir () =
     let generator = !bincaml_lifter_state.generator in
@@ -54,6 +84,8 @@ struct
     let diamond = !bincaml_lifter_state.diamond
     and address = bincaml_get_address () in
     diamond |> Aslp_state.ensure_pc_assigned ~address |> Diamond.of_zipper
+
+  (** {2 Instruction building interface implementation} *)
 
   let bigint_of_string : string -> bigint = Z.of_string_base 10
   let bigint_of_int : int -> bigint = Z.of_int
@@ -199,36 +231,6 @@ struct
   let v___BranchTaken : lexpr = BranchTaken
   let v_BTypeNext : lexpr = BTypeNext
   let v___ExclusiveLocal : lexpr = ExclusiveLocal
-
-  let f_gen_branch : expr -> branch * branch * branch =
-   fun cond ->
-    let st = !bincaml_lifter_state and ncond = Expr.BasilExpr.boolnot cond in
-
-    let left = Diamond.empty (Aslp_state.empty_block ~assume:cond ())
-    and right = Diamond.empty (Aslp_state.empty_block ~assume:ncond ())
-    and value = Aslp_state.empty_block_unconditional () in
-
-    let diamond = st.diamond |> Diamond.append_diamond ~left ~right ~value in
-    bincaml_lifter_state := { st with diamond };
-    (`T, `F, `M)
-
-  let f_switch_context : branch -> unit =
-   fun b ->
-    let diamond = !bincaml_lifter_state.diamond
-    and address = bincaml_get_address () in
-    let diamond =
-      match b with
-      | `T -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
-      | `F -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
-      | `M ->
-          diamond |> Diamond.move_out_of |> Result.get_ok
-          |> Aslp_state.ensure_pc_consistency ~address
-    in
-    bincaml_lifter_state := { !bincaml_lifter_state with diamond }
-
-  let f_true_branch : branch * branch * branch -> branch = fun (t, f, m) -> t
-  let f_false_branch : branch * branch * branch -> branch = fun (t, f, m) -> f
-  let f_merge_branch : branch * branch * branch -> branch = fun (t, f, m) -> m
 
   let f_gen_assert : expr -> unit =
    fun e -> bincaml_emit (Stmt.Instr_Assert { attrib = Attrib.empty; body = e })

--- a/lib/transforms/aslp/bincaml_ibi_make.ml
+++ b/lib/transforms/aslp/bincaml_ibi_make.ml
@@ -29,7 +29,7 @@ struct
     !bincaml_lifter_state.address |> Option.get_exn_or err
 
   (** Emits the given Bincaml statement. *)
-  let bincaml_emit stmt =
+  let bincaml_internal_emit stmt =
     bincaml_lifter_state :=
       !bincaml_lifter_state |> Aslp_state.add_stmt_to_active stmt
 
@@ -53,6 +53,8 @@ struct
   let get_ir () =
     let diamond = !bincaml_lifter_state.diamond
     and address = bincaml_get_address () in
+    if not (List.is_empty (snd diamond)) then
+      failwith "invariant violation: context switches did not return to merge";
     diamond |> Aslp_state.ensure_pc_assigned ~address |> Diamond.of_zipper
 
   let bigint_of_string : string -> bigint = Z.of_string_base 10
@@ -231,7 +233,9 @@ struct
   let f_merge_branch : branch * branch * branch -> branch = fun (t, f, m) -> m
 
   let f_gen_assert : expr -> unit =
-   fun e -> bincaml_emit (Stmt.Instr_Assert { attrib = Attrib.empty; body = e })
+   fun e ->
+    bincaml_internal_emit
+      (Stmt.Instr_Assert { attrib = Attrib.empty; body = e })
 
   let f_gen_bit_lit : bigint -> bitvector -> expr =
    fun _ bv -> Expr.BasilExpr.const (`Bitvector bv)
@@ -249,7 +253,7 @@ struct
 
   let f_gen_store : lexpr -> expr -> unit =
    fun lhs rhs ->
-    bincaml_emit
+    bincaml_internal_emit
       (Stmt.Instr_Assign
          { attrib = Attrib.empty; al = [ (Aslp_lexpr.to_var lhs, rhs) ] })
 

--- a/lib/transforms/aslp/diamond.ml
+++ b/lib/transforms/aslp/diamond.ml
@@ -225,11 +225,17 @@ let move_in_to direction :
       | `R -> Ok (right, Right { value; left; pred } :: rest)
       | `P -> Ok (pred, Pred { value; left; right } :: rest))
 
+(** Moves the zipper to the outermost ({!last}) position of the diamond. *)
+let move_to_outermost zip = zip |> of_zipper |> to_zipper
+
 (** {2 Modification functions} *)
 
 (** Modifies the zipper by inserting a new diamond {i after} the current
     position in program order, using the given parameters to build the new
-    {!constructor-Diamond}. *)
+    {!constructor-Diamond}.
+
+    This function {b invalidates} {!type-skeleton}s which point into the
+    currently-focused {!subdiamond}! *)
 let append_diamond ~left ~right ~value : 'a diamond_zipper -> 'a diamond_zipper
     = function
   | dia, path -> (dia, Pred { value; left; right } :: path)
@@ -239,7 +245,34 @@ let modify (f : 'a -> 'a) : 'a diamond_zipper -> 'a diamond_zipper = function
   | Leaf x, path -> (Leaf (f x), path)
   | Diamond x, path -> (Diamond { x with value = f x.value }, path)
 
-(** {1 Debugging} *)
+(** {1 Skeleton of a zipper} *)
+
+type skeleton = [ `L | `R | `P ] list
+[@@deriving show { with_path = false }, eq]
+(** The skeleton of a zipper is its value-less {!diamond_path}. This can be used
+    to reference a position within the {!diamond}, but it cannot reconstruct the
+    full {!diamond}, nor can it (safely) move to adjacent positions.
+
+    Being divorced from its originating {!diamond_zipper}, a {!skeleton} is
+    liable to become {i invalidated} if the zipper is drastically changed. An
+    invalidated skeleton may lead to an {!Error} while resolving, or it may
+    silently resolve to the wrong position. *)
+
+let skeleton : 'a diamond_zipper -> skeleton = function
+  | _, path ->
+      List.map (function Left _ -> `L | Right _ -> `R | Pred _ -> `P) path
+
+(** Resolves the given {!type-skeleton} within the given {!diamond}.
+
+    This takes a {!diamond} rather than a {!diamond_zipper} because a skeleton
+    is always resolved from the root. *)
+let resolve_skeleton : skeleton -> 'a diamond -> 'a diamond_zipper =
+ fun skel dia ->
+  List.fold_left
+    (fun dia dir -> move_in_to dir dia |> Result.get_ok)
+    (to_zipper dia) (List.rev skel)
+
+(** {1 Map and fold} *)
 
 let rec map f = function
   | Leaf x -> Leaf (f x)
@@ -247,14 +280,6 @@ let rec map f = function
       let value = f value in
       let left = map f left and right = map f right and pred = map f pred in
       Diamond { value; left; right; pred }
-
-type skeleton = unit diamond * [ `L | `R | `P ] list
-[@@deriving show { with_path = false }, eq]
-
-let skeleton : 'a diamond_zipper -> skeleton = function
-  | this, path ->
-      ( map (Fun.const ()) this,
-        List.map (function Left _ -> `L | Right _ -> `R | Pred _ -> `P) path )
 
 let rec cata ~(leaf : 'a -> 'b)
     ~(diamond : pred:'b -> left:'b -> right:'b -> value:'b -> 'b) dia : 'b =

--- a/lib/transforms/aslp/diamond.ml
+++ b/lib/transforms/aslp/diamond.ml
@@ -266,10 +266,11 @@ let skeleton : 'a diamond_zipper -> skeleton = function
 
     This takes a {!diamond} rather than a {!diamond_zipper} because a skeleton
     is always resolved from the root. *)
-let resolve_skeleton : skeleton -> 'a diamond -> 'a diamond_zipper =
+let resolve_skeleton :
+    skeleton -> 'a diamond -> ('a diamond_zipper, 'a diamond_zipper) result =
  fun skel dia ->
-  List.fold_left
-    (fun dia dir -> move_in_to dir dia |> Result.get_ok)
+  CCResult.fold_l
+    (fun dia dir -> move_in_to dir dia)
     (to_zipper dia) (List.rev skel)
 
 (** {1 Map and fold} *)

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -31,12 +31,15 @@ module Make (S : Params) = struct
 
   let f_gen_branch : S.expr -> branch * branch * branch =
    fun cond ->
+    let diamond = S.diamond_get () in
     let t, f, m = S.diamond_make_branch cond in
+    (match diamond with
+    | _, Pred _ :: _ ->
+        failwith "invariant violation: f_gen_branch twice without switching"
+    | _ -> ());
 
     let t = Diamond.empty t and f = Diamond.empty f in
-    let diamond =
-      S.diamond_get () |> Diamond.append_diamond ~left:t ~right:f ~value:m
-    in
+    let diamond = diamond |> Diamond.append_diamond ~left:t ~right:f ~value:m in
     S.diamond_set diamond;
 
     let t = diamond |> Diamond.move_adjacent `L |> Result.get_ok

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -50,10 +50,8 @@ module Make (S : Params) = struct
 
   let f_switch_context (skel, d, _) =
     let show b = "when moving to branch" ^ [%derive.show: [ `T | `F | `M ]] b in
-    CCResult.guard (fun () ->
-        S.diamond_get () |> Diamond.of_zipper
-        |> Diamond.resolve_skeleton skel
-        |> S.diamond_set)
+    S.diamond_get () |> Diamond.of_zipper
+    |> Diamond.resolve_skeleton skel
     |> Result.map_error (fun _ -> show d)
-    |> CCResult.get_or_failwith
+    |> CCResult.get_or_failwith |> S.diamond_set
 end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -41,10 +41,14 @@ module Make (S : Params) = struct
 
   let f_switch_context : branch -> unit =
    fun b ->
-    (b, S.diamond_get ())
-    |> ( function
-    | `T, diamond -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
-    | `F, diamond -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
-    | `M, diamond -> diamond |> Diamond.move_out_of |> Result.get_ok )
-    |> S.diamond_set
+    let show_branch_error b =
+      "while moving to branch " ^ [%derive.show: [ `T | `F | `M ]] b
+    in
+    S.diamond_get ()
+    |> (match b with
+      | `T -> Diamond.move_adjacent `L
+      | `F -> Diamond.move_adjacent `R
+      | `M -> Diamond.move_out_of)
+    |> Result.map_error (fun _ -> show_branch_error b)
+    |> CCResult.get_or_failwith |> S.diamond_set
 end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -1,0 +1,50 @@
+(** Implements control flow functionality for the IBI by using
+    {!Diamond.diamond_zipper}. *)
+
+(** Necessary parameters to provide IBI control flow functions. *)
+module type Params = sig
+  type expr
+
+  type state
+  (** Type of the state stored inside each control-flow point of the
+      {!Diamond.diamond_zipper}. *)
+
+  val diamond_get : unit -> state Diamond.diamond_zipper
+  val diamond_set : state Diamond.diamond_zipper -> unit
+
+  val diamond_make_branch : expr -> state * state * state
+  (** Should return [(t,f,m)] *)
+end
+
+(** Implements control flow functionality for the IBI by using
+    {!Diamond.diamond_zipper}. See {!module-Diamond} for more details. *)
+module Make (S : Params) = struct
+  type branch = [ `T | `F | `M ]
+  (** Branch switches are identified {b relatively} at the moment.
+
+      TODO: this is wrong in the presence of elided intermediate context
+      switches (and other non-trivial cases)! *)
+
+  let f_true_branch : branch * branch * branch -> branch = fun (t, f, m) -> t
+  let f_false_branch : branch * branch * branch -> branch = fun (t, f, m) -> f
+  let f_merge_branch : branch * branch * branch -> branch = fun (t, f, m) -> m
+
+  let f_gen_branch : S.expr -> branch * branch * branch =
+   fun cond ->
+    let t, f, m = S.diamond_make_branch cond in
+    let t = Diamond.empty t and f = Diamond.empty f in
+
+    S.diamond_get ()
+    |> Diamond.append_diamond ~left:t ~right:f ~value:m
+    |> S.diamond_set;
+    (`T, `F, `M)
+
+  let f_switch_context : branch -> unit =
+   fun b ->
+    (b, S.diamond_get ())
+    |> ( function
+    | `T, diamond -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
+    | `F, diamond -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
+    | `M, diamond -> diamond |> Diamond.move_out_of |> Result.get_ok )
+    |> S.diamond_set
+end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -41,14 +41,12 @@ module Make (S : Params) = struct
 
   let f_switch_context : branch -> unit =
    fun b ->
-    let show_branch_error b =
-      "while moving to branch " ^ [%derive.show: [ `T | `F | `M ]] b
-    in
+    let show_err b = "while moving to branch " ^ [%derive.show: branch] b in
     S.diamond_get ()
     |> (match b with
       | `T -> Diamond.move_adjacent `L
       | `F -> Diamond.move_adjacent `R
       | `M -> Diamond.move_out_of)
-    |> Result.map_error (fun _ -> show_branch_error b)
+    |> Result.map_error (fun _ -> show_err b)
     |> CCResult.get_or_failwith |> S.diamond_set
 end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -41,12 +41,12 @@ module Make (S : Params) = struct
 
   let f_switch_context : branch -> unit =
    fun b ->
-    let show_err b = "while moving to branch " ^ [%derive.show: branch] b in
+    let show b = "when moving to branch" ^ [%derive.show: [ `T | `F | `M ]] b in
     S.diamond_get ()
     |> (match b with
       | `T -> Diamond.move_adjacent `L
       | `F -> Diamond.move_adjacent `R
       | `M -> Diamond.move_out_of)
-    |> Result.map_error (fun _ -> show_err b)
+    |> Result.map_error (fun _ -> show b)
     |> CCResult.get_or_failwith |> S.diamond_set
 end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -41,12 +41,10 @@ module Make (S : Params) = struct
 
   let f_switch_context : branch -> unit =
    fun b ->
-    let show b = "when moving to branch" ^ [%derive.show: [ `T | `F | `M ]] b in
-    S.diamond_get ()
-    |> (match b with
-      | `T -> Diamond.move_adjacent `L
-      | `F -> Diamond.move_adjacent `R
-      | `M -> Diamond.move_out_of)
-    |> Result.map_error (fun _ -> show b)
-    |> CCResult.get_or_failwith |> S.diamond_set
+    (b, S.diamond_get ())
+    |> ( function
+    | `T, diamond -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
+    | `F, diamond -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
+    | `M, diamond -> diamond |> Diamond.move_out_of |> Result.get_ok )
+    |> S.diamond_set
 end

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -19,8 +19,11 @@ end
 (** Implements control flow functionality for the IBI by using
     {!Diamond.diamond_zipper}. See {!module-Diamond} for more details. *)
 module Make (S : Params) = struct
-  type branch = [ `T | `F | `M ] * Diamond.skeleton
-  (** Branch switches are a path into the diamond. *)
+  type branch = Diamond.skeleton * [ `T | `F | `M ] * S.state
+  (** Branch switches are a path into the diamond.
+
+      For downstream uses, this also records the branch direction and the state
+      value at the branch merge point. *)
 
   let f_true_branch : branch * branch * branch -> branch = fun (t, f, m) -> t
   let f_false_branch : branch * branch * branch -> branch = fun (t, f, m) -> f
@@ -39,9 +42,10 @@ module Make (S : Params) = struct
     let t = diamond |> Diamond.move_adjacent `L |> Result.get_ok
     and f = diamond |> Diamond.move_adjacent `R |> Result.get_ok in
     let m = t |> Diamond.move_out_of |> Result.get_ok in
-    Diamond.((`T, skeleton t), (`F, skeleton f), (`M, skeleton m))
+    let s = Diamond.focus m in
+    Diamond.((skeleton t, `T, s), (skeleton f, `F, s), (skeleton m, `M, s))
 
-  let f_switch_context (_, skel) =
+  let f_switch_context (skel, _, _) =
     S.diamond_get () |> Diamond.of_zipper
     |> Diamond.resolve_skeleton skel
     |> S.diamond_set

--- a/lib/transforms/aslp/diamond_ibi.ml
+++ b/lib/transforms/aslp/diamond_ibi.ml
@@ -19,11 +19,8 @@ end
 (** Implements control flow functionality for the IBI by using
     {!Diamond.diamond_zipper}. See {!module-Diamond} for more details. *)
 module Make (S : Params) = struct
-  type branch = [ `T | `F | `M ]
-  (** Branch switches are identified {b relatively} at the moment.
-
-      TODO: this is wrong in the presence of elided intermediate context
-      switches (and other non-trivial cases)! *)
+  type branch = [ `T | `F | `M ] * Diamond.skeleton
+  (** Branch switches are a path into the diamond. *)
 
   let f_true_branch : branch * branch * branch -> branch = fun (t, f, m) -> t
   let f_false_branch : branch * branch * branch -> branch = fun (t, f, m) -> f
@@ -32,19 +29,20 @@ module Make (S : Params) = struct
   let f_gen_branch : S.expr -> branch * branch * branch =
    fun cond ->
     let t, f, m = S.diamond_make_branch cond in
+
     let t = Diamond.empty t and f = Diamond.empty f in
+    let diamond =
+      S.diamond_get () |> Diamond.append_diamond ~left:t ~right:f ~value:m
+    in
+    S.diamond_set diamond;
 
-    S.diamond_get ()
-    |> Diamond.append_diamond ~left:t ~right:f ~value:m
-    |> S.diamond_set;
-    (`T, `F, `M)
+    let t = diamond |> Diamond.move_adjacent `L |> Result.get_ok
+    and f = diamond |> Diamond.move_adjacent `R |> Result.get_ok in
+    let m = t |> Diamond.move_out_of |> Result.get_ok in
+    Diamond.((`T, skeleton t), (`F, skeleton f), (`M, skeleton m))
 
-  let f_switch_context : branch -> unit =
-   fun b ->
-    (b, S.diamond_get ())
-    |> ( function
-    | `T, diamond -> diamond |> Diamond.move_adjacent `L |> Result.get_ok
-    | `F, diamond -> diamond |> Diamond.move_adjacent `R |> Result.get_ok
-    | `M, diamond -> diamond |> Diamond.move_out_of |> Result.get_ok )
+  let f_switch_context (_, skel) =
+    S.diamond_get () |> Diamond.of_zipper
+    |> Diamond.resolve_skeleton skel
     |> S.diamond_set
 end

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -5,6 +5,7 @@ open Transforms.Aslp
 let id_gen = lazy (ID.make_gen ())
 
 let make_call name =
+  Printf.printf "make_call: %s\n" name;
   Stmt.Instr_Call
     {
       attrib = Attrib.empty;
@@ -13,10 +14,18 @@ let make_call name =
       procid = (Lazy.force_val id_gen).fresh ~name ();
     }
 
+let guard f =
+  CCResult.pp CCFormat.unit Format.stdout
+    (CCResult.guard_str (fun () -> ignore (f ())))
+
+let guard_get_ir f =
+  print_endline @@ CCResult.retract
+  @@ CCResult.guard_str (fun () -> Aslp_state.show_aslp_diamond (f ()))
+
 let%expect_test "nested diamonds" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
   in
-  I.bincaml_set_address (Bitvec.of_int ~size:64 0xbadbadbad000);
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
   let branch1 = I.f_gen_branch (I.f_gen_bool_lit true) in
   I.bincaml_internal_emit (make_call "entry");
 
@@ -42,9 +51,16 @@ let%expect_test "nested diamonds" =
   I.f_switch_context (I.f_merge_branch branch1);
   I.bincaml_internal_emit (make_call "m");
 
-  print_endline @@ Aslp_state.show_aslp_diamond @@ I.get_ir ();
+  guard_get_ir I.get_ir;
   [%expect
     {|
+    make_call: entry
+    make_call: t
+    make_call: f
+    make_call: ft
+    make_call: ff
+    make_call: fm
+    make_call: m
     Diamond {
       pred =
       (Leaf
@@ -68,15 +84,199 @@ let%expect_test "nested diamonds" =
         (Leaf
            { Aslp_state.assume = boolnot(false);
              stmts =
-             [call ff();
-               (var BranchTaken:bool := false, $PC:bv64 := 0xbadbadbad004:bv64)];
-             pc_assign = (Some 0xbadbadbad004:bv64) });
+             [call ff(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+             pc_assign = (Some 0xfb3:bv64) });
         value =
         { Aslp_state.assume = true; stmts = [call fm()];
-          pc_assign = (Some if false then 0xbbb:bv64 else 0xbadbadbad004:bv64) }};
+          pc_assign = (Some if false then 0xbbb:bv64 else 0xfb3:bv64) }};
       value =
       { Aslp_state.assume = true; stmts = [call m()];
         pc_assign =
-        (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xbadbadbad004:bv64)
+        (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xfb3:bv64)
         }}
+    |}]
+
+let%expect_test "sequential diamonds" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  ( guard @@ fun () ->
+    I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+    let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
+    I.bincaml_internal_emit (make_call "entry");
+
+    I.f_switch_context (I.f_true_branch b1);
+    I.bincaml_internal_emit (make_call "b1_t");
+    I.f_switch_context (I.f_merge_branch b1);
+
+    let b2 = I.f_gen_branch (I.f_gen_bool_lit true) in
+    I.f_switch_context (I.f_true_branch b2);
+    I.bincaml_internal_emit (make_call "b2_t");
+    I.f_switch_context (I.f_merge_branch b2);
+
+    I.bincaml_internal_emit (make_call "exit");
+
+    guard_get_ir I.get_ir );
+  [%expect
+    {|
+    make_call: entry
+    make_call: b1_t
+    make_call: b2_t
+    make_call: exit
+    Diamond {
+      pred =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call entry_1()]; pc_assign = None
+             });
+        left =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call b1_t()]; pc_assign = None });
+        right =
+        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      left =
+      (Leaf { Aslp_state.assume = true; stmts = [call b2_t()]; pc_assign = None });
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call exit(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
+    ok(())
+    |}]
+
+let%expect_test "skipped merge context when going to outer merge" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+  let outer = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "entry");
+
+  I.f_switch_context (I.f_true_branch outer);
+  I.bincaml_internal_emit (make_call "t");
+
+  let inner = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.f_switch_context (I.f_true_branch inner);
+  I.bincaml_internal_emit (make_call "tt");
+  I.f_switch_context (I.f_false_branch inner);
+  I.bincaml_internal_emit (make_call "tf");
+
+  (* context switch skipped: *)
+  (* I.f_switch_context (I.f_merge_branch inner); *)
+  I.f_switch_context (I.f_merge_branch outer);
+  I.bincaml_internal_emit (make_call "m_outer");
+
+  guard_get_ir I.get_ir;
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: t
+    make_call: tt
+    make_call: tf
+    make_call: m_outer
+    Failure("invariant violation: context switches did not return to merge")
+    |}]
+
+let%expect_test "skipped merge context when going to outer branch" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+  let outer = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "entry");
+
+  I.f_switch_context (I.f_true_branch outer);
+  I.bincaml_internal_emit (make_call "t");
+
+  let inner = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.f_switch_context (I.f_true_branch inner);
+  I.bincaml_internal_emit (make_call "tt");
+  I.f_switch_context (I.f_false_branch inner);
+  I.bincaml_internal_emit (make_call "tf");
+
+  (* context switch skipped: *)
+  (* I.f_switch_context (I.f_merge_branch inner); *)
+  I.f_switch_context (I.f_false_branch outer);
+  I.bincaml_internal_emit (make_call "f");
+
+  I.f_switch_context (I.f_merge_branch outer);
+  I.bincaml_internal_emit (make_call "m_outer");
+
+  guard_get_ir I.get_ir;
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: t
+    make_call: tt
+    make_call: tf
+    make_call: f
+    make_call: m_outer
+    Failure("invariant violation: context switches did not return to merge")
+    |}]
+
+let%expect_test
+    "pathological: referencing old branch with intervening gen_branch" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+  let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "entry");
+
+  let _ = I.f_gen_branch (I.f_gen_bool_lit true) in
+  I.bincaml_internal_emit (make_call "still_in_entry");
+
+  I.f_switch_context (I.f_true_branch b1);
+  I.bincaml_internal_emit (make_call "true_of_first_branch");
+
+  I.f_switch_context (I.f_merge_branch b1);
+  I.bincaml_internal_emit (make_call "end");
+
+  guard_get_ir I.get_ir;
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: still_in_entry
+    make_call: true_of_first_branch
+    make_call: end
+    Failure("invariant violation: context switches did not return to merge")
+    |}]
+
+let%expect_test
+    "pathological: sequential diamonds, then going back into the first one" =
+  let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
+  in
+  ( guard @@ fun () ->
+    begin
+      I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+      let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
+      I.bincaml_internal_emit (make_call "entry");
+
+      I.f_switch_context (I.f_true_branch b1);
+      I.bincaml_internal_emit (make_call "b1_t");
+      I.f_switch_context (I.f_merge_branch b1);
+
+      let b2 = I.f_gen_branch (I.f_gen_bool_lit true) in
+      I.f_switch_context (I.f_true_branch b2);
+      I.bincaml_internal_emit (make_call "b2_t");
+      I.f_switch_context (I.f_merge_branch b2);
+
+      I.f_switch_context (I.f_true_branch b1);
+      I.bincaml_internal_emit (make_call "b1_t_again");
+
+      I.f_switch_context (I.f_merge_branch b2);
+      I.bincaml_internal_emit (make_call "exit");
+
+      guard_get_ir I.get_ir
+    end );
+
+  [%expect
+    {|
+    make_call: entry
+    make_call: b1_t
+    make_call: b2_t
+    error(Invalid_argument("result is Error _"))
     |}]

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -177,7 +177,29 @@ let%expect_test "skipped merge context when going to outer merge" =
     make_call: tt
     make_call: tf
     make_call: m_outer
-    Failure("invariant violation: context switches did not return to merge")
+    Diamond {
+      pred =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call entry_2()]; pc_assign = None });
+      left =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call t_1()]; pc_assign = None });
+        left =
+        (Leaf { Aslp_state.assume = true; stmts = [call tt()]; pc_assign = None });
+        right =
+        (Leaf
+           { Aslp_state.assume = boolnot(true); stmts = [call tf()];
+             pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call m_outer(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
     |}]
 
 let%expect_test "skipped merge context when going to outer branch" =
@@ -214,7 +236,33 @@ let%expect_test "skipped merge context when going to outer branch" =
     make_call: tf
     make_call: f
     make_call: m_outer
-    Failure("invariant violation: context switches did not return to merge")
+    Diamond {
+      pred =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call entry_3()]; pc_assign = None });
+      left =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call t_2()]; pc_assign = None });
+        left =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call tt_1()]; pc_assign = None });
+        right =
+        (Leaf
+           { Aslp_state.assume = boolnot(true); stmts = [call tf_1()];
+             pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      right =
+      (Leaf
+         { Aslp_state.assume = boolnot(true); stmts = [call f_1()];
+           pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call m_outer_1();
+          (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
     |}]
 
 let%expect_test
@@ -242,7 +290,28 @@ let%expect_test
     make_call: still_in_entry
     make_call: true_of_first_branch
     make_call: end
-    Failure("invariant violation: context switches did not return to merge")
+    Diamond {
+      pred =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true;
+             stmts = [call entry_4(); call still_in_entry()]; pc_assign = None });
+        left = (Leaf { Aslp_state.assume = true; stmts = []; pc_assign = None });
+        right =
+        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      left =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call true_of_first_branch()];
+           pc_assign = None });
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call end(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
     |}]
 
 let%expect_test
@@ -278,5 +347,32 @@ let%expect_test
     make_call: entry
     make_call: b1_t
     make_call: b2_t
-    error(Invalid_argument("result is Error _"))
+    make_call: b1_t_again
+    make_call: exit
+    Diamond {
+      pred =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call entry_5()]; pc_assign = None
+             });
+        left =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call b1_t_1()]; pc_assign = None
+             });
+        right =
+        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      left =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call b2_t_1(); call b1_t_again()];
+           pc_assign = None });
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call exit_1(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
+    ok(())
     |}]

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -269,55 +269,29 @@ let%expect_test
     "pathological: referencing old branch with intervening gen_branch" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
   in
-  I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
-  let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
-  I.bincaml_internal_emit (make_call "entry");
+  guard (fun () ->
+      I.bincaml_set_address (Bitvec.of_int ~size:64 0xfaf);
+      let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
+      I.bincaml_internal_emit (make_call "entry");
 
-  let b2 = I.f_gen_branch (I.f_gen_bool_lit true) in
-  I.bincaml_internal_emit (make_call "still_in_entry");
+      let b2 = I.f_gen_branch (I.f_gen_bool_lit true) in
+      I.bincaml_internal_emit (make_call "still_in_entry");
 
-  I.f_switch_context (I.f_true_branch b1);
-  I.bincaml_internal_emit (make_call "true_of_first_branch");
+      I.f_switch_context (I.f_true_branch b1);
+      I.bincaml_internal_emit (make_call "true_of_first_branch");
 
-  I.f_switch_context (I.f_false_branch b2);
-  I.bincaml_internal_emit (make_call "false_of_second_branch");
+      I.f_switch_context (I.f_false_branch b2);
+      I.bincaml_internal_emit (make_call "false_of_second_branch");
 
-  I.f_switch_context (I.f_merge_branch b1);
-  I.bincaml_internal_emit (make_call "end");
+      I.f_switch_context (I.f_merge_branch b1);
+      I.bincaml_internal_emit (make_call "end");
 
-  guard_get_ir I.get_ir;
+      guard_get_ir I.get_ir);
 
   [%expect
     {|
     make_call: entry
-    make_call: still_in_entry
-    make_call: true_of_first_branch
-    make_call: false_of_second_branch
-    make_call: end
-    Diamond {
-      pred =
-      Diamond {
-        pred =
-        (Leaf
-           { Aslp_state.assume = true;
-             stmts = [call entry_4(); call still_in_entry()]; pc_assign = None });
-        left = (Leaf { Aslp_state.assume = true; stmts = []; pc_assign = None });
-        right =
-        (Leaf
-           { Aslp_state.assume = boolnot(true);
-             stmts = [call false_of_second_branch()]; pc_assign = None });
-        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
-      left =
-      (Leaf
-         { Aslp_state.assume = true; stmts = [call true_of_first_branch()];
-           pc_assign = None });
-      right =
-      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-      value =
-      { Aslp_state.assume = true;
-        stmts =
-        [call end(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
-        pc_assign = (Some 0xfb3:bv64) }}
+    error(Failure("invariant violation: f_gen_branch twice without switching"))
     |}]
 
 let%expect_test

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -273,11 +273,14 @@ let%expect_test
   let b1 = I.f_gen_branch (I.f_gen_bool_lit true) in
   I.bincaml_internal_emit (make_call "entry");
 
-  let _ = I.f_gen_branch (I.f_gen_bool_lit true) in
+  let b2 = I.f_gen_branch (I.f_gen_bool_lit true) in
   I.bincaml_internal_emit (make_call "still_in_entry");
 
   I.f_switch_context (I.f_true_branch b1);
   I.bincaml_internal_emit (make_call "true_of_first_branch");
+
+  I.f_switch_context (I.f_false_branch b2);
+  I.bincaml_internal_emit (make_call "false_of_second_branch");
 
   I.f_switch_context (I.f_merge_branch b1);
   I.bincaml_internal_emit (make_call "end");
@@ -289,6 +292,7 @@ let%expect_test
     make_call: entry
     make_call: still_in_entry
     make_call: true_of_first_branch
+    make_call: false_of_second_branch
     make_call: end
     Diamond {
       pred =
@@ -299,7 +303,9 @@ let%expect_test
              stmts = [call entry_4(); call still_in_entry()]; pc_assign = None });
         left = (Leaf { Aslp_state.assume = true; stmts = []; pc_assign = None });
         right =
-        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        (Leaf
+           { Aslp_state.assume = boolnot(true);
+             stmts = [call false_of_second_branch()]; pc_assign = None });
         value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
       left =
       (Leaf

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -347,32 +347,6 @@ let%expect_test
     make_call: entry
     make_call: b1_t
     make_call: b2_t
-    make_call: b1_t_again
-    make_call: exit
-    Diamond {
-      pred =
-      Diamond {
-        pred =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call entry_5()]; pc_assign = None
-             });
-        left =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call b1_t_1()]; pc_assign = None
-             });
-        right =
-        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
-      left =
-      (Leaf
-         { Aslp_state.assume = true; stmts = [call b2_t_1(); call b1_t_again()];
-           pc_assign = None });
-      right =
-      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-      value =
-      { Aslp_state.assume = true;
-        stmts =
-        [call exit_1(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
-        pc_assign = (Some 0xfb3:bv64) }}
-    ok(())
+    error(
+    Failure("invariant violation: context switch did not arrive at expected point"))
     |}]

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -2,59 +2,80 @@ open Lang
 open Common
 open Transforms.Aslp
 
+let id_gen = lazy (ID.make_gen ())
+
+let make_call name =
+  Stmt.Instr_Call
+    {
+      attrib = Attrib.empty;
+      lhs = StringMap.empty;
+      args = StringMap.empty;
+      procid = (Lazy.force_val id_gen).fresh ~name ();
+    }
+
 let%expect_test "nested diamonds" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
   in
   I.bincaml_set_address (Bitvec.of_int ~size:64 0xbadbadbad000);
   let branch1 = I.f_gen_branch (I.f_gen_bool_lit true) in
-  I.f_gen_assert (I.f_gen_bool_lit true);
+  I.bincaml_internal_emit (make_call "entry");
 
   I.f_switch_context (I.f_true_branch branch1);
+  I.bincaml_internal_emit (make_call "t");
   I.f_gen_store I.v__PC
     (I.f_gen_bit_lit (I.bigint_of_int 64) (Bitvec.of_int ~size:64 0xaaa));
 
   I.f_switch_context (I.f_false_branch branch1);
+  I.bincaml_internal_emit (make_call "f");
   begin
     let branch2 = I.f_gen_branch (I.f_gen_bool_lit false) in
     I.f_switch_context (I.f_true_branch branch2);
+    I.bincaml_internal_emit (make_call "ft");
     I.f_gen_store I.v__PC
       (I.f_gen_bit_lit (I.bigint_of_int 64) (Bitvec.of_int ~size:64 0xbbb));
     I.f_switch_context (I.f_false_branch branch2);
-    I.f_switch_context (I.f_merge_branch branch2)
+    I.bincaml_internal_emit (make_call "ff");
+    I.f_switch_context (I.f_merge_branch branch2);
+    I.bincaml_internal_emit (make_call "fm")
   end;
 
   I.f_switch_context (I.f_merge_branch branch1);
-  I.f_gen_assert (I.f_gen_bool_lit false);
+  I.bincaml_internal_emit (make_call "m");
 
   print_endline @@ Aslp_state.show_aslp_diamond @@ I.get_ir ();
   [%expect
     {|
     Diamond {
       pred =
-      (Leaf { Aslp_state.assume = true; stmts = [assert true]; pc_assign = None });
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call entry()]; pc_assign = None });
       left =
       (Leaf
-         { Aslp_state.assume = true; stmts = [$PC:bv64 := 0xaaa:bv64];
+         { Aslp_state.assume = true; stmts = [call t(); $PC:bv64 := 0xaaa:bv64];
            pc_assign = (Some 0xaaa:bv64) });
       right =
       Diamond {
         pred =
-        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        (Leaf
+           { Aslp_state.assume = boolnot(true); stmts = [call f()];
+             pc_assign = None });
         left =
         (Leaf
-           { Aslp_state.assume = false; stmts = [$PC:bv64 := 0xbbb:bv64];
+           { Aslp_state.assume = false;
+             stmts = [call ft(); $PC:bv64 := 0xbbb:bv64];
              pc_assign = (Some 0xbbb:bv64) });
         right =
         (Leaf
            { Aslp_state.assume = boolnot(false);
              stmts =
-             [(var BranchTaken:bool := false, $PC:bv64 := 0xbadbadbad004:bv64)];
+             [call ff();
+               (var BranchTaken:bool := false, $PC:bv64 := 0xbadbadbad004:bv64)];
              pc_assign = (Some 0xbadbadbad004:bv64) });
         value =
-        { Aslp_state.assume = true; stmts = [];
+        { Aslp_state.assume = true; stmts = [call fm()];
           pc_assign = (Some if false then 0xbbb:bv64 else 0xbadbadbad004:bv64) }};
       value =
-      { Aslp_state.assume = true; stmts = [assert false];
+      { Aslp_state.assume = true; stmts = [call m()];
         pc_assign =
         (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xbadbadbad004:bv64)
         }}


### PR DESCRIPTION
Makes it work in the cases where a context switch is elided. This doesn't support moving to entirely arbitrary points. Also adds assertions against other pathological uses of context switching, as added in the test cases of https://github.com/agle/bincaml/pull/194.

Because our diamonds are "upside-down", the path descriptoins start from the bottom. So, they get invalidated when we push a new branch diamond sequentially after an earlier branch. This shouldn't happen in practice, but it would not be a problem if we used "right side up" diamonds. Then, paths would start from the unchanging entry point and would not be invalidated in this way. But I don't want to go back there.

This is stacked.