### PR TITLE
Clean up Aslp BFS iteration a bit

### DIFF
--- a/lib/transforms/aslp/diamond_zipper.ml
+++ b/lib/transforms/aslp/diamond_zipper.ml
@@ -228,69 +228,72 @@ let iter_zippers_backwards : 'a diamond -> 'a zipper Iter.t =
 
 (** Implementation details for BFS iteration. *)
 module Bfs_internal = struct
-  type from_direction =
-    [ `In of [ `P | `L | `R ] | `Out of [ `P | `L | `R ] | `Initial ]
-  (** Direction which a BFS traversal {i came from}. [`In] and [`Out] record the
-      field that was moved in to or out of. *)
+  let rec ktree_of_diamond (d, dia) =
+   fun () ->
+    match dia with
+    | Leaf x -> `Node ((d, x), [])
+    | Diamond { value; left; right; pred } ->
+        `Node
+          ( (d, value),
+            List.map ktree_of_diamond [ (`L, left); (`R, right); (`P, pred) ] )
 
-  type to_direction = [ `In of [ `P | `L | `R ] | `Out ]
-  (** Direction which a BFS traversal is {i going to}. *)
+  let rec ktree_of_path path : _ CCKTree.t =
+   fun () ->
+    match path with
+    | [] -> `Nil
+    | step :: rest ->
+        let value, x1, x2 =
+          match step with
+          | Pred { value; left; right } -> (value, (`L, left), (`R, right))
+          | Left { value; right; pred } -> (value, (`R, right), (`P, pred))
+          | Right { value; left; pred } -> (value, (`L, left), (`P, pred))
+        in
+        let children = List.map ktree_of_diamond [ x1; x2 ] in
+        `Node ((`S, value), ktree_of_path rest :: children)
 
-  (** Moves in a BFS direction while recording the direction moved. *)
-  let move (d : to_direction) zip : from_direction * _ result =
-    match (d, zip) with
-    | (`In d as from), _ -> (from, move_in_to d zip)
-    | `Out, Zipper (_, Pred _ :: _) -> (`Out `P, move_out_of zip)
-    | `Out, Zipper (_, Left _ :: _) -> (`Out `L, move_out_of zip)
-    | `Out, Zipper (_, Right _ :: _) -> (`Out `R, move_out_of zip)
-    | `Out, Zipper (_, []) -> (`Initial, Error zip)
+  let ktree_of_zipper (Zipper (dia, path)) : _ CCKTree.t =
+    ktree_of_diamond (`Root, dia) %> function
+    | `Node (x, children) ->
+        `Node
+          ( x,
+            ktree_of_path path
+            :: (children
+                 : (unit -> [ `Node of _ * 'b list ] as 'b) list
+                 :> _ CCKTree.t list) )
 
-  (** [directions from] returns valid adjacent directions, given that the
-      current zipper was reached from the direction [from]. [from] is used to
-      avoid going backwards. For example, if we have just gone [`In], we mustn't
-      go back [`Out]. *)
-  let directions : from_direction -> to_direction list = function
-    | `Initial -> [ `Out; `In `L; `In `R; `In `P ]
-    | `In _ -> [ `In `L; `In `R; `In `P ]
-    | `Out `P -> [ `Out; `In `L; `In `R ]
-    | `Out `L -> [ `Out; `In `R; `In `P ]
-    | `Out `R -> [ `Out; `In `L; `In `P ]
-  (* Order of this list controls iteration order within a BFS level. *)
+  let rec scan_ktree (f : 'acc -> 'a -> 'acc) acc (tree : 'a CCKTree.t) :
+      'acc CCKTree.t =
+   fun () ->
+    match tree () with
+    | `Nil -> `Nil
+    | `Node (x, children) ->
+        let acc = f acc x in
+        `Node (acc, List.map (scan_ktree f acc) children)
 
-  (** Converts the given [zip] into a tree. If this is being called recursively,
-      [from] should be set to the direction which led to [zip] to avoid cyclic
-      backtracking. In the initial call, it should be set to [`Initial] to
-      include all starting directions. *)
-  let rec to_ktree from zip : 'a zipper CCKTree.t =
-   fun () -> `Node (zip, to_ktree_successors from zip)
+  let move : 'a zipper -> [ `L | `P | `R | `Root | `S ] -> 'a zipper =
+   fun zip -> function
+    | `L -> move_in_to `L zip |> Result.get_ok
+    | `R -> move_in_to `R zip |> Result.get_ok
+    | `P -> move_in_to `P zip |> Result.get_ok
+    | `S -> move_out_of zip |> Result.get_ok
+    | `Root -> zip
 
-  and to_ktree_successors from zip : 'a zipper CCKTree.t list =
-    directions from
-    |> List.map (fun d () ->
-        match move d zip with
-        | d, Ok zip -> to_ktree d zip ()
-        | _, Error _ -> `Nil)
-  (* Additional () inside the map function defers running [move] until needed. *)
+  (** (A rough approximation of) comonad duplicate. Builds a tree of all
+      reachable zipper positions from the given zipper. *)
+  let duplicate zip =
+    scan_ktree (fun x (a, _) -> move x a) zip (ktree_of_zipper zip)
 
-  type 'a queue = 'a CCKTree.t CCSimple_queue.t
-
-  let rec bfs_tree_step (q : 'a queue) : ('a * 'a queue) option =
-    match CCSimple_queue.pop q with
-    | None -> None
-    | Some (tree, q) -> (
-        match tree () with
-        | `Nil -> bfs_tree_step q
-        | `Node (x, children) -> Some (x, CCSimple_queue.add_list q children))
-
-  (** Breadth-first search of a tree. Assumes the tree is a tree, otherwise it
-      may repeat nodes or it may not terminate. *)
-  let bfs_tree tree : _ Iter.t =
-    Iter.unfoldr bfs_tree_step (CCSimple_queue.of_list [ tree ])
+  let pset : _ CCKTree.pset =
+    object (this)
+      method add _ = this
+      method mem _ = false
+    end
 end
 
 (** Iterates over all {!zipper} positions of the given zipper, {i breadth-first}
     through the diamond structure starting from the current position. *)
-let iter_bfs st = Bfs_internal.(st |> to_ktree `Initial |> bfs_tree)
+let iter_bfs zip : _ Iter.t =
+  Iter.of_seq (CCKTree.bfs ~pset:Bfs_internal.pset (Bfs_internal.duplicate zip))
 
 (** {1 Derived functions} *)
 

--- a/lib/transforms/aslp/diamond_zipper.ml
+++ b/lib/transforms/aslp/diamond_zipper.ml
@@ -270,18 +270,17 @@ module Bfs_internal = struct
         let acc = f acc x in
         `Node (acc, List.map (scan_ktree f acc) children)
 
-  let move : 'a zipper -> [ `L | `P | `R | `Root | `S ] -> 'a zipper =
-   fun zip -> function
-    | `L -> move_in_to `L zip |> Result.get_ok
-    | `R -> move_in_to `R zip |> Result.get_ok
-    | `P -> move_in_to `P zip |> Result.get_ok
-    | `S -> move_out_of zip |> Result.get_ok
-    | `Root -> zip
+  let move : [ `L | `P | `R | `Root | `S ] -> 'a zipper -> 'a zipper = function
+    | `L -> move_in_to `L %> Result.get_ok
+    | `R -> move_in_to `R %> Result.get_ok
+    | `P -> move_in_to `P %> Result.get_ok
+    | `S -> move_out_of %> Result.get_ok
+    | `Root -> Fun.id
 
   (** (A rough approximation of) comonad duplicate. Builds a tree of all
       reachable zipper positions from the given zipper. *)
   let duplicate zip =
-    scan_ktree (fun x (a, _) -> move x a) zip (ktree_of_zipper zip)
+    scan_ktree (fun x (d, _) -> move d x) zip (ktree_of_zipper zip)
 
   let pset : _ CCKTree.pset =
     object (this)

--- a/lib/transforms/aslp/diamond_zipper.ml
+++ b/lib/transforms/aslp/diamond_zipper.ml
@@ -49,13 +49,13 @@ open Diamond
 (** Moving one step through the {!Diamond.diamond}. Each variant records the
     direction of the step, as well as the paths {i not} taken. This allows the
     {!Diamond.diamond} to be reconstructed when moving "back" through a path. *)
-type ('a, 'd) step =
-  | Left of { value : 'a; right : 'd; pred : 'd }
-  | Right of { value : 'a; left : 'd; pred : 'd }
-  | Pred of { value : 'a; left : 'd; right : 'd }
+type 'a step =
+  | Left of { value : 'a; right : 'a diamond; pred : 'a diamond }
+  | Right of { value : 'a; left : 'a diamond; pred : 'a diamond }
+  | Pred of { value : 'a; left : 'a diamond; right : 'a diamond }
 [@@deriving show { with_path = false }]
 
-type 'a path = ('a, 'a diamond) step list [@@deriving show]
+type 'a path = 'a step list [@@deriving show]
 (** A type describing a path to a "hole" in a {!Diamond.diamond}, with the
     ability to reconstruct the full {!Diamond.diamond} when the hole is filled.
 
@@ -228,115 +228,69 @@ let iter_zippers_backwards : 'a diamond -> 'a zipper Iter.t =
 
 (** Implementation details for BFS iteration. *)
 module Bfs_internal = struct
-  type 'a lazy_diamond_cell =
-    | Leaf of 'a
-    | Diamond of {
-        pred : 'a lazy_diamond;
-        left : 'a lazy_diamond;
-        right : 'a lazy_diamond;
-        value : 'a;
-      }
+  type from_direction =
+    [ `In of [ `P | `L | `R ] | `Out of [ `P | `L | `R ] | `Initial ]
+  (** Direction which a BFS traversal {i came from}. [`In] and [`Out] record the
+      field that was moved in to or out of. *)
 
-  and 'a lazy_diamond = 'a lazy_diamond_cell Lazy.t
-  (** Alternate version of {!Diamond.diamond} but with lazy recursive cells.
-      This is particularly useful to avoid eagerly computing the full diamond of
-      {!duplicate}.
+  type to_direction = [ `In of [ `P | `L | `R ] | `Out ]
+  (** Direction which a BFS traversal is {i going to}. *)
 
-      There is not great support for interoperaability between lazy and non-lazy
-      diamonds at the moment. *)
+  (** Moves in a BFS direction while recording the direction moved. *)
+  let move (d : to_direction) zip : from_direction * _ result =
+    match (d, zip) with
+    | (`In d as from), _ -> (from, move_in_to d zip)
+    | `Out, Zipper (_, Pred _ :: _) -> (`Out `P, move_out_of zip)
+    | `Out, Zipper (_, Left _ :: _) -> (`Out `L, move_out_of zip)
+    | `Out, Zipper (_, Right _ :: _) -> (`Out `R, move_out_of zip)
+    | `Out, Zipper (_, []) -> (`Initial, Error zip)
 
-  type 'a lazy_step = ('a, 'a lazy_diamond) step
-  type 'a lazy_path = 'a lazy_step Seq.t
-  type 'a lazy_zipper = LazyZipper of 'a lazy_diamond * 'a lazy_path
+  (** [directions from] returns valid adjacent directions, given that the
+      current zipper was reached from the direction [from]. [from] is used to
+      avoid going backwards. For example, if we have just gone [`In], we mustn't
+      go back [`Out]. *)
+  let directions : from_direction -> to_direction list = function
+    | `Initial -> [ `Out; `In `L; `In `R; `In `P ]
+    | `In _ -> [ `In `L; `In `R; `In `P ]
+    | `Out `P -> [ `Out; `In `L; `In `R ]
+    | `Out `L -> [ `Out; `In `R; `In `P ]
+    | `Out `R -> [ `Out; `In `L; `In `P ]
+  (* Order of this list controls iteration order within a BFS level. *)
 
-  (** Zippers {i within} the given zipper, returned as a lazy diamond with the
-      same structure as the given zipper's subdiamond.
+  (** Converts the given [zip] into a tree. If this is being called recursively,
+      [from] should be set to the direction which led to [zip] to avoid cyclic
+      backtracking. In the initial call, it should be set to [`Initial] to
+      include all starting directions. *)
+  let rec to_ktree from zip : 'a zipper CCKTree.t =
+   fun () -> `Node (zip, to_ktree_successors from zip)
 
-      The structure is unchanged! But each value position is augmented with "all
-      of the context". *)
-  let rec inner_zippers : 'a zipper -> 'a zipper lazy_diamond = function
-    | Zipper (Leaf _, path) as zip -> lazy (Leaf zip)
-    | Zipper (Diamond _, _) as zip ->
-        let left = recurse (move_in_to `L) zip
-        and right = recurse (move_in_to `R) zip
-        and pred = recurse (move_in_to `P) zip in
-        lazy (Diamond { value = zip; left; right; pred })
+  and to_ktree_successors from zip : 'a zipper CCKTree.t list =
+    directions from
+    |> List.map (fun d () ->
+        match move d zip with
+        | d, Ok zip -> to_ktree d zip ()
+        | _, Error _ -> `Nil)
+  (* Additional () inside the map function defers running [move] until needed. *)
 
-  and recurse f x = lazy (f x |> Result.get_ok |> inner_zippers |> Lazy.force)
+  type 'a queue = 'a CCKTree.t CCSimple_queue.t
 
-  (** Zippers {i above} the given zipper, returned one step layer at a time.
-      That is, the zippers obtained by walking back up the tree.
-
-      Steps out step at a time. *)
-  let outer_zippers : 'a zipper -> ('a zipper lazy_step * 'a zipper) option =
-    function
-    | Zipper (_, []) -> None
-    | Zipper (_, step :: _) as zip -> (
-        let moved_out = move_out_of zip |> Result.get_ok in
-        match step with
-        | Left _ ->
-            let right = recurse (move_adjacent `R) zip
-            and pred = recurse (move_adjacent `P) zip in
-            Some (Left { value = zip; right; pred }, moved_out)
-        | Right _ ->
-            let left = recurse (move_adjacent `L) zip
-            and pred = recurse (move_adjacent `P) zip in
-            Some (Right { value = zip; left; pred }, moved_out)
-        | Pred _ ->
-            let left = recurse (move_adjacent `L) zip
-            and right = recurse (move_adjacent `R) zip in
-            Some (Pred { value = zip; left; right }, moved_out))
-  (** It's kind of like putting each value into itself *)
-
-  (** Comonad [duplicate] implemention. Each position of the given zipper is
-      filled with the zipper focused on that position. *)
-  let duplicate : 'a zipper -> 'a zipper lazy_zipper =
-   fun zip -> LazyZipper (inner_zippers zip, CCSeq.unfold outer_zippers zip)
-
-  let rec ktree_of_diamond dia =
-   fun () ->
-    match Lazy.force dia with
-    | Leaf x -> `Node (x, [])
-    | Diamond { value; left; right; pred } ->
-        let children = List.map ktree_of_diamond [ pred; left; right ] in
-        `Node (value, children)
-
-  let rec ktree_of_path (path : _ Seq.t) : _ CCKTree.t =
-   fun () ->
-    match path () with
-    | Nil -> `Nil
-    | Cons (Pred { value; left = x1; right = x2 }, rest)
-    | Cons (Left { value; right = x1; pred = x2 }, rest)
-    | Cons (Right { value; left = x1; pred = x2 }, rest) ->
-        let children = List.map ktree_of_diamond [ x1; x2 ] in
-        `Node (value, ktree_of_path rest :: children)
-
-  let ktree_of_zipper (LazyZipper (dia, path)) : _ CCKTree.t =
-    ktree_of_diamond dia %> function
-    | `Node (x, children) ->
-        `Node
-          ( x,
-            ktree_of_path path
-            :: (children
-                 : (unit -> [ `Node of _ * 'b list ] as 'b) list
-                 :> _ CCKTree.t list) )
+  let rec bfs_tree_step (q : 'a queue) : ('a * 'a queue) option =
+    match CCSimple_queue.pop q with
+    | None -> None
+    | Some (tree, q) -> (
+        match tree () with
+        | `Nil -> bfs_tree_step q
+        | `Node (x, children) -> Some (x, CCSimple_queue.add_list q children))
 
   (** Breadth-first search of a tree. Assumes the tree is a tree, otherwise it
       may repeat nodes or it may not terminate. *)
-  let bfs_tree ktree =
-    let noop_pset =
-      object (this)
-        method add _ = this
-        method mem _ = false
-      end
-    in
-    CCKTree.bfs ~pset:noop_pset ktree
+  let bfs_tree tree : _ Iter.t =
+    Iter.unfoldr bfs_tree_step (CCSimple_queue.of_list [ tree ])
 end
 
 (** Iterates over all {!zipper} positions of the given zipper, {i breadth-first}
     through the diamond structure starting from the current position. *)
-let iter_bfs zip =
-  Bfs_internal.(zip |> duplicate |> ktree_of_zipper |> bfs_tree) |> Iter.of_seq
+let iter_bfs st = Bfs_internal.(st |> to_ktree `Initial |> bfs_tree)
 
 (** {1 Derived functions} *)
 

--- a/lib/transforms/aslp/diamond_zipper.ml
+++ b/lib/transforms/aslp/diamond_zipper.ml
@@ -228,7 +228,7 @@ let iter_zippers_backwards : 'a diamond -> 'a zipper Iter.t =
 
 (** Implementation details for BFS iteration. *)
 module Bfs_internal = struct
-  let rec ktree_of_diamond (d, dia) =
+  let rec ktree_of_diamond (d, dia) : _ CCKTree.t =
    fun () ->
     match dia with
     | Leaf x -> `Node ((d, x), [])
@@ -253,13 +253,8 @@ module Bfs_internal = struct
 
   let ktree_of_zipper (Zipper (dia, path)) : _ CCKTree.t =
     ktree_of_diamond (`Root, dia) %> function
-    | `Node (x, children) ->
-        `Node
-          ( x,
-            ktree_of_path path
-            :: (children
-                 : (unit -> [ `Node of _ * 'b list ] as 'b) list
-                 :> _ CCKTree.t list) )
+    | `Nil -> failwith "impossible"
+    | `Node (x, children) -> `Node (x, ktree_of_path path :: children)
 
   let rec scan_ktree (f : 'acc -> 'a -> 'acc) acc (tree : 'a CCKTree.t) :
       'acc CCKTree.t =

--- a/lib/transforms/aslp/diamond_zipper.ml
+++ b/lib/transforms/aslp/diamond_zipper.ml
@@ -49,13 +49,13 @@ open Diamond
 (** Moving one step through the {!Diamond.diamond}. Each variant records the
     direction of the step, as well as the paths {i not} taken. This allows the
     {!Diamond.diamond} to be reconstructed when moving "back" through a path. *)
-type 'a step =
-  | Left of { value : 'a; right : 'a diamond; pred : 'a diamond }
-  | Right of { value : 'a; left : 'a diamond; pred : 'a diamond }
-  | Pred of { value : 'a; left : 'a diamond; right : 'a diamond }
+type ('a, 'd) step =
+  | Left of { value : 'a; right : 'd; pred : 'd }
+  | Right of { value : 'a; left : 'd; pred : 'd }
+  | Pred of { value : 'a; left : 'd; right : 'd }
 [@@deriving show { with_path = false }]
 
-type 'a path = 'a step list [@@deriving show]
+type 'a path = ('a, 'a diamond) step list [@@deriving show]
 (** A type describing a path to a "hole" in a {!Diamond.diamond}, with the
     ability to reconstruct the full {!Diamond.diamond} when the hole is filled.
 
@@ -228,69 +228,115 @@ let iter_zippers_backwards : 'a diamond -> 'a zipper Iter.t =
 
 (** Implementation details for BFS iteration. *)
 module Bfs_internal = struct
-  type from_direction =
-    [ `In of [ `P | `L | `R ] | `Out of [ `P | `L | `R ] | `Initial ]
-  (** Direction which a BFS traversal {i came from}. [`In] and [`Out] record the
-      field that was moved in to or out of. *)
+  type 'a lazy_diamond_cell =
+    | Leaf of 'a
+    | Diamond of {
+        pred : 'a lazy_diamond;
+        left : 'a lazy_diamond;
+        right : 'a lazy_diamond;
+        value : 'a;
+      }
 
-  type to_direction = [ `In of [ `P | `L | `R ] | `Out ]
-  (** Direction which a BFS traversal is {i going to}. *)
+  and 'a lazy_diamond = 'a lazy_diamond_cell Lazy.t
+  (** Alternate version of {!Diamond.diamond} but with lazy recursive cells.
+      This is particularly useful to avoid eagerly computing the full diamond of
+      {!duplicate}.
 
-  (** Moves in a BFS direction while recording the direction moved. *)
-  let move (d : to_direction) zip : from_direction * _ result =
-    match (d, zip) with
-    | (`In d as from), _ -> (from, move_in_to d zip)
-    | `Out, Zipper (_, Pred _ :: _) -> (`Out `P, move_out_of zip)
-    | `Out, Zipper (_, Left _ :: _) -> (`Out `L, move_out_of zip)
-    | `Out, Zipper (_, Right _ :: _) -> (`Out `R, move_out_of zip)
-    | `Out, Zipper (_, []) -> (`Initial, Error zip)
+      There is not great support for interoperaability between lazy and non-lazy
+      diamonds at the moment. *)
 
-  (** [directions from] returns valid adjacent directions, given that the
-      current zipper was reached from the direction [from]. [from] is used to
-      avoid going backwards. For example, if we have just gone [`In], we mustn't
-      go back [`Out]. *)
-  let directions : from_direction -> to_direction list = function
-    | `Initial -> [ `Out; `In `L; `In `R; `In `P ]
-    | `In _ -> [ `In `L; `In `R; `In `P ]
-    | `Out `P -> [ `Out; `In `L; `In `R ]
-    | `Out `L -> [ `Out; `In `R; `In `P ]
-    | `Out `R -> [ `Out; `In `L; `In `P ]
-  (* Order of this list controls iteration order within a BFS level. *)
+  type 'a lazy_step = ('a, 'a lazy_diamond) step
+  type 'a lazy_path = 'a lazy_step Seq.t
+  type 'a lazy_zipper = LazyZipper of 'a lazy_diamond * 'a lazy_path
 
-  (** Converts the given [zip] into a tree. If this is being called recursively,
-      [from] should be set to the direction which led to [zip] to avoid cyclic
-      backtracking. In the initial call, it should be set to [`Initial] to
-      include all starting directions. *)
-  let rec to_ktree from zip : 'a zipper CCKTree.t =
-   fun () -> `Node (zip, to_ktree_successors from zip)
+  (** Zippers {i within} the given zipper, returned as a lazy diamond with the
+      same structure as the given zipper's subdiamond.
 
-  and to_ktree_successors from zip : 'a zipper CCKTree.t list =
-    directions from
-    |> List.map (fun d () ->
-        match move d zip with
-        | d, Ok zip -> to_ktree d zip ()
-        | _, Error _ -> `Nil)
-  (* Additional () inside the map function defers running [move] until needed. *)
+      The structure is unchanged! But each value position is augmented with "all
+      of the context". *)
+  let rec inner_zippers : 'a zipper -> 'a zipper lazy_diamond = function
+    | Zipper (Leaf _, path) as zip -> lazy (Leaf zip)
+    | Zipper (Diamond _, _) as zip ->
+        let left = recurse (move_in_to `L) zip
+        and right = recurse (move_in_to `R) zip
+        and pred = recurse (move_in_to `P) zip in
+        lazy (Diamond { value = zip; left; right; pred })
 
-  type 'a queue = 'a CCKTree.t CCSimple_queue.t
+  and recurse f x = lazy (f x |> Result.get_ok |> inner_zippers |> Lazy.force)
 
-  let rec bfs_tree_step (q : 'a queue) : ('a * 'a queue) option =
-    match CCSimple_queue.pop q with
-    | None -> None
-    | Some (tree, q) -> (
-        match tree () with
-        | `Nil -> bfs_tree_step q
-        | `Node (x, children) -> Some (x, CCSimple_queue.add_list q children))
+  (** Zippers {i above} the given zipper, returned one step layer at a time.
+      That is, the zippers obtained by walking back up the tree.
+
+      Steps out step at a time. *)
+  let outer_zippers : 'a zipper -> ('a zipper lazy_step * 'a zipper) option =
+    function
+    | Zipper (_, []) -> None
+    | Zipper (_, step :: _) as zip -> (
+        let moved_out = move_out_of zip |> Result.get_ok in
+        match step with
+        | Left _ ->
+            let right = recurse (move_adjacent `R) zip
+            and pred = recurse (move_adjacent `P) zip in
+            Some (Left { value = zip; right; pred }, moved_out)
+        | Right _ ->
+            let left = recurse (move_adjacent `L) zip
+            and pred = recurse (move_adjacent `P) zip in
+            Some (Right { value = zip; left; pred }, moved_out)
+        | Pred _ ->
+            let left = recurse (move_adjacent `L) zip
+            and right = recurse (move_adjacent `R) zip in
+            Some (Pred { value = zip; left; right }, moved_out))
+  (** It's kind of like putting each value into itself *)
+
+  (** Comonad [duplicate] implemention. Each position of the given zipper is
+      filled with the zipper focused on that position. *)
+  let duplicate : 'a zipper -> 'a zipper lazy_zipper =
+   fun zip -> LazyZipper (inner_zippers zip, CCSeq.unfold outer_zippers zip)
+
+  let rec ktree_of_diamond dia =
+   fun () ->
+    match Lazy.force dia with
+    | Leaf x -> `Node (x, [])
+    | Diamond { value; left; right; pred } ->
+        let children = List.map ktree_of_diamond [ pred; left; right ] in
+        `Node (value, children)
+
+  let rec ktree_of_path (path : _ Seq.t) : _ CCKTree.t =
+   fun () ->
+    match path () with
+    | Nil -> `Nil
+    | Cons (Pred { value; left = x1; right = x2 }, rest)
+    | Cons (Left { value; right = x1; pred = x2 }, rest)
+    | Cons (Right { value; left = x1; pred = x2 }, rest) ->
+        let children = List.map ktree_of_diamond [ x1; x2 ] in
+        `Node (value, ktree_of_path rest :: children)
+
+  let ktree_of_zipper (LazyZipper (dia, path)) : _ CCKTree.t =
+    ktree_of_diamond dia %> function
+    | `Node (x, children) ->
+        `Node
+          ( x,
+            ktree_of_path path
+            :: (children
+                 : (unit -> [ `Node of _ * 'b list ] as 'b) list
+                 :> _ CCKTree.t list) )
 
   (** Breadth-first search of a tree. Assumes the tree is a tree, otherwise it
       may repeat nodes or it may not terminate. *)
-  let bfs_tree tree : _ Iter.t =
-    Iter.unfoldr bfs_tree_step (CCSimple_queue.of_list [ tree ])
+  let bfs_tree ktree =
+    let noop_pset =
+      object (this)
+        method add _ = this
+        method mem _ = false
+      end
+    in
+    CCKTree.bfs ~pset:noop_pset ktree
 end
 
 (** Iterates over all {!zipper} positions of the given zipper, {i breadth-first}
     through the diamond structure starting from the current position. *)
-let iter_bfs st = Bfs_internal.(st |> to_ktree `Initial |> bfs_tree)
+let iter_bfs zip =
+  Bfs_internal.(zip |> duplicate |> ktree_of_zipper |> bfs_tree) |> Iter.of_seq
 
 (** {1 Derived functions} *)
 

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -69,22 +69,25 @@ let%expect_test "lift: b.eq #1024" =
       (Bitvec.of_string "0x54002000:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_diamond x;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-  (Invalid_argument "f_switch_context: cannot find matching position")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
-  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
-  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
-  Called from Transforms__Aslp.lift_opcode.(fun) in file "lib/transforms/aslp/aslp.ml", line 27, characters 6-67
-  Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
-  Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
-  Called from Test_aslp.(fun) in file "test/transforms/test_aslp.ml", lines 66-69, characters 4-42
-  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
-  |}]
+  [%expect
+    {|
+    Diamond {
+      pred = (Leaf { Aslp_state.assume = true; stmts = []; pc_assign = None });
+      left =
+      (Leaf
+         { Aslp_state.assume = eq($PSTATE_Z, 0x1:bv1);
+           stmts = [var BranchTaken:bool := true; $PC:bv64 := 0x2400:bv64];
+           pc_assign = (Some 0x2400:bv64) });
+      right =
+      (Leaf
+         { Aslp_state.assume = boolnot(eq($PSTATE_Z, 0x1:bv1));
+           stmts = [(var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
+           pc_assign = (Some 0x2004:bv64) });
+      value =
+      { Aslp_state.assume = true; stmts = [];
+        pc_assign =
+        (Some if eq($PSTATE_Z, 0x1:bv1) then 0x2400:bv64 else 0x2004:bv64) }}
+    |}]
 
 let%expect_test "lift: b #16" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
@@ -319,37 +322,126 @@ proc @Sqrt()  -> () {  }
   let prog = transform_program lst.prog in
   print_endline
   @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-  (Invalid_argument "f_switch_context: cannot find matching position")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
-  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
-  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
-  Called from Transforms__Aslp.lift_opcode.(fun) in file "lib/transforms/aslp/aslp.ml", line 27, characters 6-67
-  Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
-  Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
-  Called from Stdlib__List.mapi in file "list.ml", line 93, characters 15-21
-  Called from Transforms__Aslp.transform_block in file "lib/transforms/aslp/aslp.ml", line 159, characters 19-62
-  Called from Iter.fold.(fun) in file "src/Iter.ml", line 77, characters 23-31
-  Called from Stdlib__Set.Make.iter in file "set.ml", line 379, characters 35-38
-  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 20-25
-  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 10-18
-  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 10-18
-  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 10-18
-  Called from Iter.fold in file "src/Iter.ml", line 77, characters 2-32
-  Called from Lang__Program.map_procedures.(fun) in file "lib/lang/program.ml", line 136, characters 63-77
-  Called from Stdlib__Map.Make.mapi in file "map.ml", line 321, characters 19-24
-  Called from Stdlib__Map.Make.mapi in file "map.ml", line 322, characters 19-27
-  Called from Stdlib__Map.Make.mapi in file "map.ml", line 322, characters 19-27
-  Called from Lang__Program.map_procedures in file "lib/lang/program.ml", lines 134-137, characters 6-17
-  Called from Transforms__Aslp.transform_program in file "lib/transforms/aslp/aslp.ml", lines 221-222, characters 2-76
-  Called from Test_aslp.(fun) in file "test/transforms/test_aslp.ml", line 322, characters 13-39
-  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
-  |}]
+  [%expect
+    {|
+    var observable $mem:(bv64->bv8);
+    var $PC:bv64;
+    proc @Sqrt()  -> () {  }
+      captures $PC:bv64
+
+    [
+       block %Sqrt_code_4 { .address = 4196316 } [
+         assume eq(0x4007dc:bv64, $PC);
+         goto (%block);
+       ];
+       block %block { .asm = "b.lt #0x10" } [
+         guard true;
+         goto (%block_2,%block_1);
+       ];
+       block %block_1 [
+         guard boolnot(eq($PSTATE_N, $PSTATE_V));
+         var BranchTaken:bool := true;
+         $PC:bv64 := 0x4007ec:bv64;
+         goto (%block_3);
+       ];
+       block %block_2 [
+         guard boolnot(boolnot(eq($PSTATE_N, $PSTATE_V)));
+         (var BranchTaken:bool := false, $PC:bv64 := 0x4007e0:bv64);
+         goto (%block_3);
+       ];
+       block %block_3 [
+         guard true;
+         $PC:bv64 := if boolnot(eq($PSTATE_N, $PSTATE_V)) then 0x4007ec:bv64 else 0x4007e0:bv64;
+         assert boolor(eq(0x4007fc:bv64, $PC), eq(0x4007e0:bv64, $PC));
+         goto (%Sqrt_code_3,%Sqrt_code);
+       ];
+       block %Sqrt_code [ assume eq(0x4007e0:bv64, $PC); goto (%ret); ];
+       block %Sqrt_code_3 [ assume eq(0x4007fc:bv64, $PC); goto (%ret); ];
+       block %ret [ return; ]
+    ];
+    var $SP:bv64;
+    var $R0:bv64;
+    var $R1:bv64;
+    var $R2:bv64;
+    var $R3:bv64;
+    var $R4:bv64;
+    var $R5:bv64;
+    var $R6:bv64;
+    var $R7:bv64;
+    var $R8:bv64;
+    var $R9:bv64;
+    var $R10:bv64;
+    var $R11:bv64;
+    var $R12:bv64;
+    var $R13:bv64;
+    var $R14:bv64;
+    var $R15:bv64;
+    var $R16:bv64;
+    var $R17:bv64;
+    var $R18:bv64;
+    var $R19:bv64;
+    var $R20:bv64;
+    var $R21:bv64;
+    var $R22:bv64;
+    var $R23:bv64;
+    var $R24:bv64;
+    var $R25:bv64;
+    var $R26:bv64;
+    var $R27:bv64;
+    var $R28:bv64;
+    var $R29:bv64;
+    var $R30:bv64;
+    var $Z0:bv128;
+    var $Z1:bv128;
+    var $Z2:bv128;
+    var $Z3:bv128;
+    var $Z4:bv128;
+    var $Z5:bv128;
+    var $Z6:bv128;
+    var $Z7:bv128;
+    var $Z8:bv128;
+    var $Z9:bv128;
+    var $Z10:bv128;
+    var $Z11:bv128;
+    var $Z12:bv128;
+    var $Z13:bv128;
+    var $Z14:bv128;
+    var $Z15:bv128;
+    var $Z16:bv128;
+    var $Z17:bv128;
+    var $Z18:bv128;
+    var $Z19:bv128;
+    var $Z20:bv128;
+    var $Z21:bv128;
+    var $Z22:bv128;
+    var $Z23:bv128;
+    var $Z24:bv128;
+    var $Z25:bv128;
+    var $Z26:bv128;
+    var $Z27:bv128;
+    var $Z28:bv128;
+    var $Z29:bv128;
+    var $Z30:bv128;
+    var $FPSR:bv64;
+    var $FPCR:bv64;
+    var $PSTATE_N:bv1;
+    var $PSTATE_Z:bv1;
+    var $PSTATE_C:bv1;
+    var $PSTATE_V:bv1;
+    var $PSTATE_A:bv1;
+    var $PSTATE_D:bv1;
+    var $PSTATE_DIT:bv1;
+    var $PSTATE_F:bv1;
+    var $PSTATE_I:bv1;
+    var $PSTATE_PAN:bv1;
+    var $PSTATE_SP:bv1;
+    var $PSTATE_SSBS:bv1;
+    var $PSTATE_TCO:bv1;
+    var $PSTATE_UAO:bv1;
+    var $PSTATE_BTYPE:bv1;
+    var $ExclusiveLocal:bool;
+    prog entry @Sqrt;
+    |}]
 
 let%expect_test "aslp integration with no aarch64_eval intrins" =
   let lst =

--- a/test/transforms/test_aslp.ml
+++ b/test/transforms/test_aslp.ml
@@ -69,25 +69,22 @@ let%expect_test "lift: b.eq #1024" =
       (Bitvec.of_string "0x54002000:bv32")
   in
   print_endline @@ Aslp_state.show_aslp_diamond x;
-  [%expect
-    {|
-    Diamond {
-      pred = (Leaf { Aslp_state.assume = true; stmts = []; pc_assign = None });
-      left =
-      (Leaf
-         { Aslp_state.assume = eq($PSTATE_Z, 0x1:bv1);
-           stmts = [var BranchTaken:bool := true; $PC:bv64 := 0x2400:bv64];
-           pc_assign = (Some 0x2400:bv64) });
-      right =
-      (Leaf
-         { Aslp_state.assume = boolnot(eq($PSTATE_Z, 0x1:bv1));
-           stmts = [(var BranchTaken:bool := false, $PC:bv64 := 0x2004:bv64)];
-           pc_assign = (Some 0x2004:bv64) });
-      value =
-      { Aslp_state.assume = true; stmts = [];
-        pc_assign =
-        (Some if eq($PSTATE_Z, 0x1:bv1) then 0x2400:bv64 else 0x2004:bv64) }}
-    |}]
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+  (Invalid_argument "f_switch_context: cannot find matching position")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
+  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
+  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
+  Called from Transforms__Aslp.lift_opcode.(fun) in file "lib/transforms/aslp/aslp.ml", line 27, characters 6-67
+  Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
+  Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
+  Called from Test_aslp.(fun) in file "test/transforms/test_aslp.ml", lines 66-69, characters 4-42
+  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
+  |}]
 
 let%expect_test "lift: b #16" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
@@ -322,126 +319,37 @@ proc @Sqrt()  -> () {  }
   let prog = transform_program lst.prog in
   print_endline
   @@ Containers_pp.Pretty.to_string ~width:80 (Lang.Program.prog_pretty prog);
-  [%expect
-    {|
-    var observable $mem:(bv64->bv8);
-    var $PC:bv64;
-    proc @Sqrt()  -> () {  }
-      captures $PC:bv64
-
-    [
-       block %Sqrt_code_4 { .address = 4196316 } [
-         assume eq(0x4007dc:bv64, $PC);
-         goto (%block);
-       ];
-       block %block { .asm = "b.lt #0x10" } [
-         guard true;
-         goto (%block_2,%block_1);
-       ];
-       block %block_1 [
-         guard boolnot(eq($PSTATE_N, $PSTATE_V));
-         var BranchTaken:bool := true;
-         $PC:bv64 := 0x4007ec:bv64;
-         goto (%block_3);
-       ];
-       block %block_2 [
-         guard boolnot(boolnot(eq($PSTATE_N, $PSTATE_V)));
-         (var BranchTaken:bool := false, $PC:bv64 := 0x4007e0:bv64);
-         goto (%block_3);
-       ];
-       block %block_3 [
-         guard true;
-         $PC:bv64 := if boolnot(eq($PSTATE_N, $PSTATE_V)) then 0x4007ec:bv64 else 0x4007e0:bv64;
-         assert boolor(eq(0x4007fc:bv64, $PC), eq(0x4007e0:bv64, $PC));
-         goto (%Sqrt_code_3,%Sqrt_code);
-       ];
-       block %Sqrt_code [ assume eq(0x4007e0:bv64, $PC); goto (%ret); ];
-       block %Sqrt_code_3 [ assume eq(0x4007fc:bv64, $PC); goto (%ret); ];
-       block %ret [ return; ]
-    ];
-    var $SP:bv64;
-    var $R0:bv64;
-    var $R1:bv64;
-    var $R2:bv64;
-    var $R3:bv64;
-    var $R4:bv64;
-    var $R5:bv64;
-    var $R6:bv64;
-    var $R7:bv64;
-    var $R8:bv64;
-    var $R9:bv64;
-    var $R10:bv64;
-    var $R11:bv64;
-    var $R12:bv64;
-    var $R13:bv64;
-    var $R14:bv64;
-    var $R15:bv64;
-    var $R16:bv64;
-    var $R17:bv64;
-    var $R18:bv64;
-    var $R19:bv64;
-    var $R20:bv64;
-    var $R21:bv64;
-    var $R22:bv64;
-    var $R23:bv64;
-    var $R24:bv64;
-    var $R25:bv64;
-    var $R26:bv64;
-    var $R27:bv64;
-    var $R28:bv64;
-    var $R29:bv64;
-    var $R30:bv64;
-    var $Z0:bv128;
-    var $Z1:bv128;
-    var $Z2:bv128;
-    var $Z3:bv128;
-    var $Z4:bv128;
-    var $Z5:bv128;
-    var $Z6:bv128;
-    var $Z7:bv128;
-    var $Z8:bv128;
-    var $Z9:bv128;
-    var $Z10:bv128;
-    var $Z11:bv128;
-    var $Z12:bv128;
-    var $Z13:bv128;
-    var $Z14:bv128;
-    var $Z15:bv128;
-    var $Z16:bv128;
-    var $Z17:bv128;
-    var $Z18:bv128;
-    var $Z19:bv128;
-    var $Z20:bv128;
-    var $Z21:bv128;
-    var $Z22:bv128;
-    var $Z23:bv128;
-    var $Z24:bv128;
-    var $Z25:bv128;
-    var $Z26:bv128;
-    var $Z27:bv128;
-    var $Z28:bv128;
-    var $Z29:bv128;
-    var $Z30:bv128;
-    var $FPSR:bv64;
-    var $FPCR:bv64;
-    var $PSTATE_N:bv1;
-    var $PSTATE_Z:bv1;
-    var $PSTATE_C:bv1;
-    var $PSTATE_V:bv1;
-    var $PSTATE_A:bv1;
-    var $PSTATE_D:bv1;
-    var $PSTATE_DIT:bv1;
-    var $PSTATE_F:bv1;
-    var $PSTATE_I:bv1;
-    var $PSTATE_PAN:bv1;
-    var $PSTATE_SP:bv1;
-    var $PSTATE_SSBS:bv1;
-    var $PSTATE_TCO:bv1;
-    var $PSTATE_UAO:bv1;
-    var $PSTATE_BTYPE:bv1;
-    var $ExclusiveLocal:bool;
-    prog entry @Sqrt;
-    |}]
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+  (Invalid_argument "f_switch_context: cannot find matching position")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
+  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
+  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
+  Called from Transforms__Aslp.lift_opcode.(fun) in file "lib/transforms/aslp/aslp.ml", line 27, characters 6-67
+  Called from Stdlib__Fun.protect in file "fun.ml", line 34, characters 8-15
+  Re-raised at Stdlib__Fun.protect in file "fun.ml", line 39, characters 6-52
+  Called from Stdlib__List.mapi in file "list.ml", line 93, characters 15-21
+  Called from Transforms__Aslp.transform_block in file "lib/transforms/aslp/aslp.ml", line 159, characters 19-62
+  Called from Iter.fold.(fun) in file "src/Iter.ml", line 77, characters 23-31
+  Called from Stdlib__Set.Make.iter in file "set.ml", line 379, characters 35-38
+  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 20-25
+  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 10-18
+  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 10-18
+  Called from Stdlib__Map.Make.iter in file "map.ml", line 305, characters 10-18
+  Called from Iter.fold in file "src/Iter.ml", line 77, characters 2-32
+  Called from Lang__Program.map_procedures.(fun) in file "lib/lang/program.ml", line 136, characters 63-77
+  Called from Stdlib__Map.Make.mapi in file "map.ml", line 321, characters 19-24
+  Called from Stdlib__Map.Make.mapi in file "map.ml", line 322, characters 19-27
+  Called from Stdlib__Map.Make.mapi in file "map.ml", line 322, characters 19-27
+  Called from Lang__Program.map_procedures in file "lib/lang/program.ml", lines 134-137, characters 6-17
+  Called from Transforms__Aslp.transform_program in file "lib/transforms/aslp/aslp.ml", lines 221-222, characters 2-76
+  Called from Test_aslp.(fun) in file "test/transforms/test_aslp.ml", line 322, characters 13-39
+  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
+  |}]
 
 let%expect_test "aslp integration with no aarch64_eval intrins" =
   let lst =

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -40,7 +40,7 @@ let%expect_test "diamond bfs" =
     Diamond_zipper.(main |> of_diamond |> move_in_to `L |> Result.get_ok)
   in
   CCFormat.output Format.stdout (CCKTree.pp CCString.pp)
-    (Diamond_zipper.Bfs_internal.to_ktree `Initial zip
+    (Diamond_zipper.Bfs_internal.duplicate zip
     |> CCKTree.map Diamond_zipper.focus);
   [%expect
     {|

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -39,22 +39,41 @@ let%expect_test "diamond bfs" =
   let zip =
     Diamond_zipper.(main |> of_diamond |> move_in_to `L |> Result.get_ok)
   in
+  CCFormat.output Format.stdout (CCKTree.pp CCString.pp)
+    (Diamond_zipper.Bfs_internal.to_ktree `Initial zip
+    |> CCKTree.map Diamond_zipper.focus);
+  [%expect
+    {|
+    ("left_merge"
+      ("merge"
+        ("right_merge"
+          "right_left"
+          "right_right"
+          "right_pred")
+        ("pred_merge"
+          "pred_left"
+          "pred_right"
+          "pred_pred"))
+      "left_left"
+      "left_right"
+      "left_pred")
+|}];
   Diamond_zipper.iter_bfs zip |> Iter.iter (print_endline % Diamond_zipper.focus);
   [%expect
     {|
     left_merge
-    left_merge
-    left_pred
+    merge
     left_left
     left_right
+    left_pred
     right_merge
     pred_merge
-    right_pred
     right_left
     right_right
-    pred_pred
+    right_pred
     pred_left
     pred_right
+    pred_pred
     |}]
 
 let%expect_test "nested diamonds" =
@@ -87,28 +106,49 @@ let%expect_test "nested diamonds" =
   I.bincaml_internal_emit (make_call "m");
 
   guard_get_ir I.get_ir;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-  (Invalid_argument "f_switch_context: cannot find matching position")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
-  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
-  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
-  Called from Test_aslp__Test_aslp_ibi.(fun) in file "test/transforms/test_aslp_ibi.ml", line 86, characters 2-47
-  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
-
-  Trailing output
-  ---------------
-  make_call: entry
-  make_call: t
-  make_call: f
-  make_call: ft
-  make_call: ff
-  make_call: fm
-  |}]
+  [%expect
+    {|
+    make_call: entry
+    make_call: t
+    make_call: f
+    make_call: ft
+    make_call: ff
+    make_call: fm
+    make_call: m
+    Diamond {
+      pred =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call entry()]; pc_assign = None });
+      left =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call t(); $PC:bv64 := 0xaaa:bv64];
+           pc_assign = (Some 0xaaa:bv64) });
+      right =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = boolnot(true); stmts = [call f()];
+             pc_assign = None });
+        left =
+        (Leaf
+           { Aslp_state.assume = false;
+             stmts = [call ft(); $PC:bv64 := 0xbbb:bv64];
+             pc_assign = (Some 0xbbb:bv64) });
+        right =
+        (Leaf
+           { Aslp_state.assume = boolnot(false);
+             stmts =
+             [call ff(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+             pc_assign = (Some 0xfb3:bv64) });
+        value =
+        { Aslp_state.assume = true; stmts = [call fm()];
+          pc_assign = (Some if false then 0xbbb:bv64 else 0xfb3:bv64) }};
+      value =
+      { Aslp_state.assume = true; stmts = [call m()];
+        pc_assign =
+        (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xfb3:bv64)
+        }}
+    |}]
 
 let%expect_test "sequential diamonds" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
@@ -134,7 +174,31 @@ let%expect_test "sequential diamonds" =
     {|
     make_call: entry
     make_call: b1_t
-    error(Invalid_argument("f_switch_context: cannot find matching position"))
+    make_call: b2_t
+    make_call: exit
+    Diamond {
+      pred =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call entry_1()]; pc_assign = None
+             });
+        left =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call b1_t()]; pc_assign = None });
+        right =
+        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      left =
+      (Leaf { Aslp_state.assume = true; stmts = [call b2_t()]; pc_assign = None });
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call exit(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
+    ok(())
     |}]
 
 let%expect_test "skipped merge context when going to outer merge" =
@@ -160,26 +224,37 @@ let%expect_test "skipped merge context when going to outer merge" =
 
   guard_get_ir I.get_ir;
 
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-  (Invalid_argument "f_switch_context: cannot find matching position")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
-  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
-  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
-  Called from Test_aslp__Test_aslp_ibi.(fun) in file "test/transforms/test_aslp_ibi.ml", line 203, characters 2-45
-  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
-
-  Trailing output
-  ---------------
-  make_call: entry
-  make_call: t
-  make_call: tt
-  make_call: tf
-  |}]
+  [%expect
+    {|
+    make_call: entry
+    make_call: t
+    make_call: tt
+    make_call: tf
+    make_call: m_outer
+    Diamond {
+      pred =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call entry_2()]; pc_assign = None });
+      left =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call t_1()]; pc_assign = None });
+        left =
+        (Leaf { Aslp_state.assume = true; stmts = [call tt()]; pc_assign = None });
+        right =
+        (Leaf
+           { Aslp_state.assume = boolnot(true); stmts = [call tf()];
+             pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call m_outer(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
+    |}]
 
 let%expect_test "skipped merge context when going to outer branch" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
@@ -207,27 +282,42 @@ let%expect_test "skipped merge context when going to outer branch" =
 
   guard_get_ir I.get_ir;
 
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-  (Invalid_argument "f_switch_context: cannot find matching position")
-  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
-  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
-  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
-  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
-  Called from Test_aslp__Test_aslp_ibi.(fun) in file "test/transforms/test_aslp_ibi.ml", line 261, characters 2-45
-  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
-
-  Trailing output
-  ---------------
-  make_call: entry
-  make_call: t
-  make_call: tt
-  make_call: tf
-  make_call: f
-  |}]
+  [%expect
+    {|
+    make_call: entry
+    make_call: t
+    make_call: tt
+    make_call: tf
+    make_call: f
+    make_call: m_outer
+    Diamond {
+      pred =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call entry_3()]; pc_assign = None });
+      left =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call t_2()]; pc_assign = None });
+        left =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call tt_1()]; pc_assign = None });
+        right =
+        (Leaf
+           { Aslp_state.assume = boolnot(true); stmts = [call tf_1()];
+             pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      right =
+      (Leaf
+         { Aslp_state.assume = boolnot(true); stmts = [call f_1()];
+           pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call m_outer_1();
+          (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
+    |}]
 
 let%expect_test
     "pathological: referencing old branch with intervening gen_branch" =
@@ -290,5 +380,32 @@ let%expect_test
     {|
     make_call: entry
     make_call: b1_t
-    error(Invalid_argument("f_switch_context: cannot find matching position"))
+    make_call: b2_t
+    make_call: b1_t_again
+    make_call: exit
+    Diamond {
+      pred =
+      Diamond {
+        pred =
+        (Leaf
+           { Aslp_state.assume = true; stmts = [call entry_5()]; pc_assign = None
+             });
+        left =
+        (Leaf
+           { Aslp_state.assume = true;
+             stmts = [call b1_t_1(); call b1_t_again()]; pc_assign = None });
+        right =
+        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
+      left =
+      (Leaf
+         { Aslp_state.assume = true; stmts = [call b2_t_1()]; pc_assign = None });
+      right =
+      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
+      value =
+      { Aslp_state.assume = true;
+        stmts =
+        [call exit_1(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
+        pc_assign = (Some 0xfb3:bv64) }}
+    ok(())
     |}]

--- a/test/transforms/test_aslp_ibi.ml
+++ b/test/transforms/test_aslp_ibi.ml
@@ -39,41 +39,22 @@ let%expect_test "diamond bfs" =
   let zip =
     Diamond_zipper.(main |> of_diamond |> move_in_to `L |> Result.get_ok)
   in
-  CCFormat.output Format.stdout (CCKTree.pp CCString.pp)
-    (Diamond_zipper.Bfs_internal.to_ktree `Initial zip
-    |> CCKTree.map Diamond_zipper.focus);
-  [%expect
-    {|
-    ("left_merge"
-      ("merge"
-        ("right_merge"
-          "right_left"
-          "right_right"
-          "right_pred")
-        ("pred_merge"
-          "pred_left"
-          "pred_right"
-          "pred_pred"))
-      "left_left"
-      "left_right"
-      "left_pred")
-|}];
   Diamond_zipper.iter_bfs zip |> Iter.iter (print_endline % Diamond_zipper.focus);
   [%expect
     {|
     left_merge
-    merge
+    left_merge
+    left_pred
     left_left
     left_right
-    left_pred
     right_merge
     pred_merge
+    right_pred
     right_left
     right_right
-    right_pred
+    pred_pred
     pred_left
     pred_right
-    pred_pred
     |}]
 
 let%expect_test "nested diamonds" =
@@ -106,49 +87,28 @@ let%expect_test "nested diamonds" =
   I.bincaml_internal_emit (make_call "m");
 
   guard_get_ir I.get_ir;
-  [%expect
-    {|
-    make_call: entry
-    make_call: t
-    make_call: f
-    make_call: ft
-    make_call: ff
-    make_call: fm
-    make_call: m
-    Diamond {
-      pred =
-      (Leaf
-         { Aslp_state.assume = true; stmts = [call entry()]; pc_assign = None });
-      left =
-      (Leaf
-         { Aslp_state.assume = true; stmts = [call t(); $PC:bv64 := 0xaaa:bv64];
-           pc_assign = (Some 0xaaa:bv64) });
-      right =
-      Diamond {
-        pred =
-        (Leaf
-           { Aslp_state.assume = boolnot(true); stmts = [call f()];
-             pc_assign = None });
-        left =
-        (Leaf
-           { Aslp_state.assume = false;
-             stmts = [call ft(); $PC:bv64 := 0xbbb:bv64];
-             pc_assign = (Some 0xbbb:bv64) });
-        right =
-        (Leaf
-           { Aslp_state.assume = boolnot(false);
-             stmts =
-             [call ff(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
-             pc_assign = (Some 0xfb3:bv64) });
-        value =
-        { Aslp_state.assume = true; stmts = [call fm()];
-          pc_assign = (Some if false then 0xbbb:bv64 else 0xfb3:bv64) }};
-      value =
-      { Aslp_state.assume = true; stmts = [call m()];
-        pc_assign =
-        (Some if true then 0xaaa:bv64 else if false then 0xbbb:bv64 else 0xfb3:bv64)
-        }}
-    |}]
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+  (Invalid_argument "f_switch_context: cannot find matching position")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
+  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
+  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
+  Called from Test_aslp__Test_aslp_ibi.(fun) in file "test/transforms/test_aslp_ibi.ml", line 86, characters 2-47
+  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
+
+  Trailing output
+  ---------------
+  make_call: entry
+  make_call: t
+  make_call: f
+  make_call: ft
+  make_call: ff
+  make_call: fm
+  |}]
 
 let%expect_test "sequential diamonds" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
@@ -174,31 +134,7 @@ let%expect_test "sequential diamonds" =
     {|
     make_call: entry
     make_call: b1_t
-    make_call: b2_t
-    make_call: exit
-    Diamond {
-      pred =
-      Diamond {
-        pred =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call entry_1()]; pc_assign = None
-             });
-        left =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call b1_t()]; pc_assign = None });
-        right =
-        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
-      left =
-      (Leaf { Aslp_state.assume = true; stmts = [call b2_t()]; pc_assign = None });
-      right =
-      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-      value =
-      { Aslp_state.assume = true;
-        stmts =
-        [call exit(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
-        pc_assign = (Some 0xfb3:bv64) }}
-    ok(())
+    error(Invalid_argument("f_switch_context: cannot find matching position"))
     |}]
 
 let%expect_test "skipped merge context when going to outer merge" =
@@ -224,37 +160,26 @@ let%expect_test "skipped merge context when going to outer merge" =
 
   guard_get_ir I.get_ir;
 
-  [%expect
-    {|
-    make_call: entry
-    make_call: t
-    make_call: tt
-    make_call: tf
-    make_call: m_outer
-    Diamond {
-      pred =
-      (Leaf
-         { Aslp_state.assume = true; stmts = [call entry_2()]; pc_assign = None });
-      left =
-      Diamond {
-        pred =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call t_1()]; pc_assign = None });
-        left =
-        (Leaf { Aslp_state.assume = true; stmts = [call tt()]; pc_assign = None });
-        right =
-        (Leaf
-           { Aslp_state.assume = boolnot(true); stmts = [call tf()];
-             pc_assign = None });
-        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
-      right =
-      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-      value =
-      { Aslp_state.assume = true;
-        stmts =
-        [call m_outer(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
-        pc_assign = (Some 0xfb3:bv64) }}
-    |}]
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+  (Invalid_argument "f_switch_context: cannot find matching position")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
+  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
+  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
+  Called from Test_aslp__Test_aslp_ibi.(fun) in file "test/transforms/test_aslp_ibi.ml", line 203, characters 2-45
+  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
+
+  Trailing output
+  ---------------
+  make_call: entry
+  make_call: t
+  make_call: tt
+  make_call: tf
+  |}]
 
 let%expect_test "skipped merge context when going to outer branch" =
   let module I = (val Bincaml_ibi.from_generator (Aslp_state.empty_aslp_ids ()))
@@ -282,42 +207,27 @@ let%expect_test "skipped merge context when going to outer branch" =
 
   guard_get_ir I.get_ir;
 
-  [%expect
-    {|
-    make_call: entry
-    make_call: t
-    make_call: tt
-    make_call: tf
-    make_call: f
-    make_call: m_outer
-    Diamond {
-      pred =
-      (Leaf
-         { Aslp_state.assume = true; stmts = [call entry_3()]; pc_assign = None });
-      left =
-      Diamond {
-        pred =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call t_2()]; pc_assign = None });
-        left =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call tt_1()]; pc_assign = None });
-        right =
-        (Leaf
-           { Aslp_state.assume = boolnot(true); stmts = [call tf_1()];
-             pc_assign = None });
-        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
-      right =
-      (Leaf
-         { Aslp_state.assume = boolnot(true); stmts = [call f_1()];
-           pc_assign = None });
-      value =
-      { Aslp_state.assume = true;
-        stmts =
-        [call m_outer_1();
-          (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
-        pc_assign = (Some 0xfb3:bv64) }}
-    |}]
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+  (Invalid_argument "f_switch_context: cannot find matching position")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from CCOption.get_exn_or in file "src/core/CCOption.pp.ml" (inlined), line 97, characters 12-27
+  Called from Transforms__Aslp__Diamond_ibi.Make.f_switch_context in file "lib/transforms/aslp/diamond_ibi.ml", lines 63-65, characters 4-76
+  Called from Transforms__Aslp__Bincaml_ibi_make.Make.f_switch_context in file "lib/transforms/aslp/bincaml_ibi_make.ml", line 71, characters 4-29
+  Called from Test_aslp__Test_aslp_ibi.(fun) in file "test/transforms/test_aslp_ibi.ml", line 261, characters 2-45
+  Called from Ppx_expect_runtime__Test_block.Configured.dump_backtrace in file "runtime/test_block.ml", line 142, characters 10-28
+
+  Trailing output
+  ---------------
+  make_call: entry
+  make_call: t
+  make_call: tt
+  make_call: tf
+  make_call: f
+  |}]
 
 let%expect_test
     "pathological: referencing old branch with intervening gen_branch" =
@@ -380,32 +290,5 @@ let%expect_test
     {|
     make_call: entry
     make_call: b1_t
-    make_call: b2_t
-    make_call: b1_t_again
-    make_call: exit
-    Diamond {
-      pred =
-      Diamond {
-        pred =
-        (Leaf
-           { Aslp_state.assume = true; stmts = [call entry_5()]; pc_assign = None
-             });
-        left =
-        (Leaf
-           { Aslp_state.assume = true;
-             stmts = [call b1_t_1(); call b1_t_again()]; pc_assign = None });
-        right =
-        (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-        value = { Aslp_state.assume = true; stmts = []; pc_assign = None }};
-      left =
-      (Leaf
-         { Aslp_state.assume = true; stmts = [call b2_t_1()]; pc_assign = None });
-      right =
-      (Leaf { Aslp_state.assume = boolnot(true); stmts = []; pc_assign = None });
-      value =
-      { Aslp_state.assume = true;
-        stmts =
-        [call exit_1(); (var BranchTaken:bool := false, $PC:bv64 := 0xfb3:bv64)];
-        pc_assign = (Some 0xfb3:bv64) }}
-    ok(())
+    error(Invalid_argument("f_switch_context: cannot find matching position"))
     |}]


### PR DESCRIPTION
To be honest, it is debatable whether this is easier to read than the old code.

I think it is slightly, because you don't need do so much bookkeeping of directions. It also makes the tree structure more explicit and adds a scan function.