### PR TITLE
Acyclic CFA reduction

### DIFF
--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -207,6 +207,15 @@ module PassManager = struct
       invariants = Invariants.presupposes [ Params ] ~establishes:[ SSA ];
     }
 
+  let cfa_reduction =
+    {
+      name = "cfa-reduction";
+      apply = Proc Transforms.Cfa_reduction.reduce_procedure;
+      doc =
+        "Performs reduction of acyclic CFA";
+      invariants = Invariants.presupposes [ SSA ];
+    }
+
   let remove_unreachable_blocks =
     {
       name = "remove-unreachable-block";
@@ -462,6 +471,7 @@ module PassManager = struct
       read_uninit false;
       read_uninit true;
       sssa;
+      cfa_reduction;
       sva;
       full_ssa;
       chc_infer_invariants;

--- a/lib/passes.ml
+++ b/lib/passes.ml
@@ -211,8 +211,7 @@ module PassManager = struct
     {
       name = "cfa-reduction";
       apply = Proc Transforms.Cfa_reduction.reduce_procedure;
-      doc =
-        "Performs reduction of acyclic CFA";
+      doc = "Performs reduction of acyclic CFA";
       invariants = Invariants.presupposes [ SSA ];
     }
 

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -1,24 +1,35 @@
+(**
+  A transform which reduces the CFA (control-flow automaton)
+  to a single edge, representing control flow through linear
+  if-then-else expressions rather than phi nodes.
+
+  The original algorithm assumes no SSA, however this does
+  as it simplifies it greatly. Also assumes the CFA is acyclic
+  and pure.
+  *)
+
 open Lang
 open Lang.Common
+open Expr
 
-(* Assumes program is in SSA, acyclic and pure. *)
 let construct_final_edge proc =
   (* Termination condition for each edge. *)
-  let term : (IDSet.elt, Var.t) Hashtbl.t = Hashtbl.create 30 in
+  let termination_condition : (IDSet.elt, Var.t) Hashtbl.t =
+    Hashtbl.create 30
+  in
   Procedure.fold_blocks_topo_fwd
     (fun final_edge id block ->
-      let preds = Procedure.blocks_pred proc id |> Iter.to_list in
-
       (* Compute reachability of this block. *)
       let reachable =
+        match Procedure.blocks_pred proc id |> Iter.to_list with
         (* Always reachable if no predecessors. *)
-        if List.is_empty preds then Expr.BasilExpr.boolconst true
+        | [] -> Expr.BasilExpr.boolconst true
         (* Otherwise, reachability is ANY of the predecessors reachability. *)
-          else
-          Expr.BasilExpr.applyintrin ~op:`OR
-            (preds
-            |> List.filter_map (fst %> Hashtbl.get term)
-            |> List.map Expr.BasilExpr.rvar)
+        | preds ->
+            Expr.BasilExpr.applyintrin ~op:`OR
+              (preds
+              |> List.filter_map (fst %> Hashtbl.get termination_condition)
+              |> List.map Expr.BasilExpr.rvar)
       in
 
       (* Create ITE statements from phi nodes. *)
@@ -26,15 +37,14 @@ let construct_final_edge proc =
         let al =
           block.phis
           |> List.map (function
-            | ({ lhs; rhs = hd :: tl } : Var.t Block.phi) ->
+            | ({ lhs; rhs = (_, hd_var) :: tl } : Var.t Block.phi) ->
+                (* Head id is unused as it is the negation of everything. *)
                 let ite =
                   List.fold_left
                     (fun acc (in_edge, var) ->
-                      Expr.BasilExpr.ifthenelse
-                        (Expr.BasilExpr.rvar @@ Hashtbl.find term in_edge)
-                        (Expr.BasilExpr.rvar var) acc)
-                    (Expr.BasilExpr.rvar @@ snd hd)
-                    tl
+                      let cond = Hashtbl.find termination_condition in_edge in
+                      BasilExpr.(ifthenelse (rvar @@ cond) (rvar var) acc))
+                    (BasilExpr.rvar @@ hd_var) tl
                 in
                 (lhs, ite)
             | _ -> failwith "Encountered phi node with no rhs.")
@@ -44,19 +54,22 @@ let construct_final_edge proc =
 
       (* Add a fresh termination variable to assign the condition. *)
       let termination_var = Procedure.fresh_var proc ~pure:true Types.Boolean in
-      Hashtbl.add term id termination_var;
+      Hashtbl.add termination_condition id termination_var;
+
+      (* Isolate the guard statements. *)
+      let guard_expressions, non_guard_stmts =
+        Block.stmts_iter block |> Iter.to_list
+        |> List.partition_map_either (function
+          | Stmt.Instr_Assume { body; branch = true } -> Left body
+          | stmt -> Right stmt)
+      in
 
       (* Construct our termination condition by combining
-          initial reachability with any assumes along this edge. *)
+          initial reachability with any guards along this edge. *)
       let termination_cond =
-        Expr.BasilExpr.applyintrin ~op:`AND
-          ([ reachable ]
-          @ (Block.stmts_iter block
-            |> Iter.filter_map (function
-              | Stmt.Instr_Assume { body; branch = true } -> Some body
-              | _ -> None)
-            |> Iter.to_list))
+        BasilExpr.applyintrin ~op:`AND (reachable :: guard_expressions)
       in
+
       let termination =
         Stmt.Instr_Assign
           {
@@ -70,35 +83,22 @@ let construct_final_edge proc =
           2. the statements for the new edge body.
           3. an assignment to the termination variable.
         *)
-      final_edge
-      @ List.concat
-          [
-            [ ites ];
-            (* Filter out the now unnecessary guards. *)
-            block.stmts |> Vector.to_list
-            |> List.filter (fun s ->
-                not
-                @@
-                match s with
-                | Stmt.Instr_Assume { branch = true } -> true
-                | _ -> false);
-            [ termination ];
-          ])
-    List.empty proc
+      final_edge @ List.concat [ [ ites ]; non_guard_stmts; [ termination ] ])
+    [] proc
 
 let reduce_procedure (proc : Program.proc) : Program.proc =
   (* Constructed reduced edge to replace procedure blocks. *)
   let final_edge = construct_final_edge proc in
 
-  let out_proc =
+  let proc =
     proc |> Procedure.iter_blocks |> Iter.map fst
     |> Iter.fold (fun acc id -> Procedure.remove_block acc id) proc
   in
-  let out_proc, id = Procedure.fresh_block out_proc ~stmts:final_edge () in
+  let proc, id = Procedure.fresh_block proc ~stmts:final_edge () in
 
   (* Make this the entry and return block. *)
-  let out_proc = Procedure.set_entry_block out_proc id in
+  let proc = Procedure.set_entry_block proc id in
   Procedure.PG.map_graph
     (fun g ->
       Procedure.G.add_edge g (Procedure.Vert.End id) Procedure.Vert.Return)
-    out_proc
+    proc

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -1,11 +1,17 @@
 (**
   A transform which reduces the CFA (control-flow automaton)
   to a single edge, representing control flow through linear
-  if-then-else expressions rather than phi nodes.
+  if-then-else expressions rather than phi nodes. This is
+  useful for the SMT backend.
+
+  This is done by propagating reachability and termination
+  conditions for blocks forwards in topological order.
+  Phi-node variables then be assigned from an ite-chain on
+  the termination condition of each source block.
 
   The original algorithm assumes no SSA, however this does
-  as it simplifies it greatly. Also assumes the CFA is acyclic
-  and pure.
+  as it simplifies it greatly. Also requires that the CFA
+  is acyclic and pure.
   *)
 
 open Lang
@@ -17,6 +23,12 @@ let construct_final_edge proc =
   let termination_condition : (IDSet.elt, Var.t) Hashtbl.t =
     Hashtbl.create 30
   in
+
+  (* final_edge accumulates as one large edge containing
+     all statements from existing edges with additional
+     predicate variables and ite statements/assignments
+     filling in for phi-nodes. 
+  *)
   Procedure.fold_blocks_topo_fwd
     (fun final_edge id block ->
       (* Compute reachability of this block. *)

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -1,0 +1,117 @@
+open Lang
+open Lang.Common
+
+(* Assumptions: SSA form probably? seems good to me! *)
+(* Also that the program is pure and lacks loops... *)
+let reduce_procedure (proc : Program.proc) : Program.proc =
+  (* Liveness of variables at start of edge. *)
+  (* let live : (Procedure.Edge.block, VarSet.t) Hashtbl.t = *)
+  (* Procedure.blocks_to_list proc *)
+  (* |> List.map (fun (v, b) -> (b, Block.free_vars b)) *)
+  (* |> Hashtbl.of_list *)
+  (* in *)
+
+  (* Termination condition for each edge. *)
+  let term : (IDSet.elt, Var.t) Hashtbl.t = Hashtbl.create 30 in
+
+  (* Constructed reduced edge to replace procedure edges. *)
+  let final_edge =
+    Procedure.fold_blocks_topo_fwd
+      (fun final_edge id block ->
+        let preds = Procedure.blocks_pred proc id |> Iter.to_list in
+
+        (* Compute reachability of this block. *)
+        let reachable =
+          (* Always reachable if no predecessors. *)
+          if List.is_empty preds then Expr.BasilExpr.boolconst true
+          (* Otherwise, reachability is ANY of the predecessors reachability. *)
+            else
+            Expr.BasilExpr.applyintrin ~op:`OR
+              (preds
+              |> List.filter_map (fst %> Hashtbl.get term)
+              |> List.map Expr.BasilExpr.rvar)
+        in
+
+        (* Create ITE statements from phi nodes. *)
+        let ites : Program.stmt =
+          let al =
+            block.phis
+            |> List.map (function
+              | ({ lhs; rhs = hd :: tl } : Var.t Block.phi) ->
+                  let ite =
+                    List.fold_left
+                      (fun acc (in_edge, var) ->
+                        Expr.BasilExpr.ifthenelse
+                          (Expr.BasilExpr.rvar @@ Hashtbl.find term in_edge)
+                          (Expr.BasilExpr.rvar var) acc)
+                      (Expr.BasilExpr.rvar @@ snd hd)
+                      tl
+                  in
+                  (lhs, ite)
+              | _ -> failwith "Encountered phi node with no rhs.")
+          in
+          Stmt.Instr_Assign { attrib = Attrib.empty; al }
+        in
+
+        (* Construct our termination condition by combining
+          initial reachability with any assumes along this edge. *)
+        let termination_var =
+          Procedure.fresh_var proc ~pure:true Types.Boolean
+        in
+        Hashtbl.add term id termination_var;
+        let termination_cond = reachable in
+        let termination =
+          Stmt.Instr_Assign
+            {
+              attrib = Attrib.empty;
+              al = [ (termination_var, termination_cond) ];
+            }
+        in
+
+        final_edge
+        @ List.concat
+            [ [ ites ]; block.stmts |> Vector.to_list; [ termination ] ])
+      List.empty proc
+  in
+
+  failwith ""
+
+(* module Reduction = struct *)
+(* type t = { *)
+(* Variables live at the start of an edge. *)
+(* TODO: should be Edge -> Varset.t *)
+(* live : (Procedure.Edge.block, VarSet.t) Hashtbl.t; *)
+(* Terminating condition variable for each edge. *)
+(* term : (Procedure.Edge.block, Var.t) Hashtbl.t; *)
+(* Variable renaming at termination of an edge. *)
+(* names : (Procedure.Edge.block, Var.t) Hashtbl.t; *)
+(* Statement list of the new single-edge procedure. *)
+(* final_edge : Program.stmt list; *)
+(* } *)
+
+(* let create (proc : Program.proc) : t = *)
+(* { *)
+(* live = *)
+(* Procedure.blocks_to_list proc *)
+(* |> List.map (fun (v, b) -> (b, Block.free_vars b)) *)
+(* |> Hashtbl.of_list; *)
+(* term = Hashtbl.create 30; *)
+(* names = Hashtbl.create 30; *)
+(* final_edge = List.empty; *)
+(* } *)
+(* end *)
+
+(* Assumptions: SSA form probably? seems good to me! *)
+(* Also that the program is pure and lacks loops... *)
+(* let reduce_procedure (proc : Program.proc) : Program.proc = *)
+(* let reduction = Reduction.create proc in *)
+(* let reduction = *)
+(* Procedure.fold_blocks_topo_fwd *)
+(* (fun final_edge id block -> *)
+(* let preds = () in *)
+(* let reachable = () in *)
+(* Hashtbl.add (reduction.live) *)
+(* final_edge) *)
+(* reduction proc *)
+(* in *)
+(* failwith "" *)

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -3,115 +3,87 @@ open Lang.Common
 
 (* Assumptions: SSA form probably? seems good to me! *)
 (* Also that the program is pure and lacks loops... *)
-let reduce_procedure (proc : Program.proc) : Program.proc =
-  (* Liveness of variables at start of edge. *)
-  (* let live : (Procedure.Edge.block, VarSet.t) Hashtbl.t = *)
-  (* Procedure.blocks_to_list proc *)
-  (* |> List.map (fun (v, b) -> (b, Block.free_vars b)) *)
-  (* |> Hashtbl.of_list *)
-  (* in *)
-
+let construct_final_edge proc =
   (* Termination condition for each edge. *)
   let term : (IDSet.elt, Var.t) Hashtbl.t = Hashtbl.create 30 in
+  Procedure.fold_blocks_topo_fwd
+    (fun final_edge id block ->
+      let preds = Procedure.blocks_pred proc id |> Iter.to_list in
 
-  (* Constructed reduced edge to replace procedure edges. *)
-  let final_edge =
-    Procedure.fold_blocks_topo_fwd
-      (fun final_edge id block ->
-        let preds = Procedure.blocks_pred proc id |> Iter.to_list in
+      (* Compute reachability of this block. *)
+      let reachable =
+        (* Always reachable if no predecessors. *)
+        if List.is_empty preds then Expr.BasilExpr.boolconst true
+        (* Otherwise, reachability is ANY of the predecessors reachability. *)
+          else
+          Expr.BasilExpr.applyintrin ~op:`OR
+            (preds
+            |> List.filter_map (fst %> Hashtbl.get term)
+            |> List.map Expr.BasilExpr.rvar)
+      in
 
-        (* Compute reachability of this block. *)
-        let reachable =
-          (* Always reachable if no predecessors. *)
-          if List.is_empty preds then Expr.BasilExpr.boolconst true
-          (* Otherwise, reachability is ANY of the predecessors reachability. *)
-            else
-            Expr.BasilExpr.applyintrin ~op:`OR
-              (preds
-              |> List.filter_map (fst %> Hashtbl.get term)
-              |> List.map Expr.BasilExpr.rvar)
+      (* Create ITE statements from phi nodes. *)
+      let ites : Program.stmt =
+        let al =
+          block.phis
+          |> List.map (function
+            | ({ lhs; rhs = hd :: tl } : Var.t Block.phi) ->
+                let ite =
+                  List.fold_left
+                    (fun acc (in_edge, var) ->
+                      Expr.BasilExpr.ifthenelse
+                        (Expr.BasilExpr.rvar @@ Hashtbl.find term in_edge)
+                        (Expr.BasilExpr.rvar var) acc)
+                    (Expr.BasilExpr.rvar @@ snd hd)
+                    tl
+                in
+                (lhs, ite)
+            | _ -> failwith "Encountered phi node with no rhs.")
         in
+        Stmt.Instr_Assign { attrib = Attrib.empty; al }
+      in
 
-        (* Create ITE statements from phi nodes. *)
-        let ites : Program.stmt =
-          let al =
-            block.phis
-            |> List.map (function
-              | ({ lhs; rhs = hd :: tl } : Var.t Block.phi) ->
-                  let ite =
-                    List.fold_left
-                      (fun acc (in_edge, var) ->
-                        Expr.BasilExpr.ifthenelse
-                          (Expr.BasilExpr.rvar @@ Hashtbl.find term in_edge)
-                          (Expr.BasilExpr.rvar var) acc)
-                      (Expr.BasilExpr.rvar @@ snd hd)
-                      tl
-                  in
-                  (lhs, ite)
-              | _ -> failwith "Encountered phi node with no rhs.")
-          in
-          Stmt.Instr_Assign { attrib = Attrib.empty; al }
-        in
+      (* Add a fresh termination variable to assign the condition. *)
+      let termination_var = Procedure.fresh_var proc ~pure:true Types.Boolean in
+      Hashtbl.add term id termination_var;
 
-        (* Construct our termination condition by combining
+      (* Construct our termination condition by combining
           initial reachability with any assumes along this edge. *)
-        let termination_var =
-          Procedure.fresh_var proc ~pure:true Types.Boolean
-        in
-        Hashtbl.add term id termination_var;
-        let termination_cond = reachable in
-        let termination =
-          Stmt.Instr_Assign
-            {
-              attrib = Attrib.empty;
-              al = [ (termination_var, termination_cond) ];
-            }
-        in
+      let termination_cond =
+        Expr.BasilExpr.applyintrin ~op:`AND
+          ([ reachable ]
+          @ (Block.stmts_iter block
+            |> Iter.filter_map (function
+              | Stmt.Instr_Assume { body; branch } -> Some body
+              | _ -> None)
+            |> Iter.to_list))
+      in
+      let termination =
+        Stmt.Instr_Assign
+          {
+            attrib = Attrib.empty;
+            al = [ (termination_var, termination_cond) ];
+          }
+      in
 
-        final_edge
-        @ List.concat
-            [ [ ites ]; block.stmts |> Vector.to_list; [ termination ] ])
-      List.empty proc
-  in
+      (* Final edge is existing statements plus:
+          1. the ites for the new edge being merged in.
+          2. the statements for the new edge body.
+          3. an assignment to the termination variable.
+        *)
+      final_edge
+      @ List.concat [ [ ites ]; block.stmts |> Vector.to_list; [ termination ] ])
+    List.empty proc
 
-  failwith ""
+let reduce_procedure (proc : Program.proc) : Program.proc =
+  (* Constructed reduced edge to replace procedure blocks. *)
+  let final_edge = construct_final_edge proc in
 
-(* module Reduction = struct *)
-(* type t = { *)
-(* Variables live at the start of an edge. *)
-(* TODO: should be Edge -> Varset.t *)
-(* live : (Procedure.Edge.block, VarSet.t) Hashtbl.t; *)
-(* Terminating condition variable for each edge. *)
-(* term : (Procedure.Edge.block, Var.t) Hashtbl.t; *)
-(* Variable renaming at termination of an edge. *)
-(* names : (Procedure.Edge.block, Var.t) Hashtbl.t; *)
-(* Statement list of the new single-edge procedure. *)
-(* final_edge : Program.stmt list; *)
-(* } *)
+  let out_proc, id = Procedure.fresh_block proc ~stmts:final_edge () in
 
-(* let create (proc : Program.proc) : t = *)
-(* { *)
-(* live = *)
-(* Procedure.blocks_to_list proc *)
-(* |> List.map (fun (v, b) -> (b, Block.free_vars b)) *)
-(* |> Hashtbl.of_list; *)
-(* term = Hashtbl.create 30; *)
-(* names = Hashtbl.create 30; *)
-(* final_edge = List.empty; *)
-(* } *)
-(* end *)
-
-(* Assumptions: SSA form probably? seems good to me! *)
-(* Also that the program is pure and lacks loops... *)
-(* let reduce_procedure (proc : Program.proc) : Program.proc = *)
-(* let reduction = Reduction.create proc in *)
-(* let reduction = *)
-(* Procedure.fold_blocks_topo_fwd *)
-(* (fun final_edge id block -> *)
-(* let preds = () in *)
-(* let reachable = () in *)
-(* Hashtbl.add (reduction.live) *)
-(* final_edge) *)
-(* reduction proc *)
-(* in *)
-(* failwith "" *)
+  (* Make this the entry and return block. *)
+  let out_proc = Procedure.set_entry_block out_proc id in
+  Procedure.PG.map_graph
+    (fun g ->
+      Procedure.G.add_edge g (Procedure.Vert.End id) Procedure.Vert.Return)
+    out_proc

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -1,18 +1,13 @@
-(**
-  A transform which reduces the CFA (control-flow automaton)
-  to a single edge, representing control flow through linear
-  if-then-else expressions rather than phi nodes. This is
-  useful for the SMT backend.
+(** A transform which reduces the CFA (control-flow automaton) to a single edge,
+    representing control flow through linear if-then-else expressions rather
+    than phi nodes. This is useful for the SMT backend.
 
-  This is done by propagating reachability and termination
-  conditions for blocks forwards in topological order.
-  Phi-node variables then be assigned from an ite-chain on
-  the termination condition of each source block.
+    This is done by propagating reachability and termination conditions for
+    blocks forwards in topological order. Phi-node variables then be assigned
+    from an ite-chain on the termination condition of each source block.
 
-  The original algorithm assumes no SSA, however this does
-  as it simplifies it greatly. Also requires that the CFA
-  is acyclic and pure.
-  *)
+    The original algorithm assumes no SSA, however this does as it simplifies it
+    greatly. Also requires that the CFA is acyclic and pure. *)
 
 open Lang
 open Lang.Common

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -53,7 +53,7 @@ let construct_final_edge proc =
           ([ reachable ]
           @ (Block.stmts_iter block
             |> Iter.filter_map (function
-              | Stmt.Instr_Assume { body; branch } -> Some body
+              | Stmt.Instr_Assume { body; branch = true } -> Some body
               | _ -> None)
             |> Iter.to_list))
       in
@@ -71,7 +71,19 @@ let construct_final_edge proc =
           3. an assignment to the termination variable.
         *)
       final_edge
-      @ List.concat [ [ ites ]; block.stmts |> Vector.to_list; [ termination ] ])
+      @ List.concat
+          [
+            [ ites ];
+            (* Filter out the now unnecessary guards. *)
+            block.stmts |> Vector.to_list
+            |> List.filter (fun s ->
+                not
+                @@
+                match s with
+                | Stmt.Instr_Assume { branch = true } -> true
+                | _ -> false);
+            [ termination ];
+          ])
     List.empty proc
 
 let reduce_procedure (proc : Program.proc) : Program.proc =

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -79,7 +79,11 @@ let reduce_procedure (proc : Program.proc) : Program.proc =
   (* Constructed reduced edge to replace procedure blocks. *)
   let final_edge = construct_final_edge proc in
 
-  let out_proc, id = Procedure.fresh_block proc ~stmts:final_edge () in
+  let out_proc =
+    proc |> Procedure.iter_blocks |> Iter.map fst
+    |> Iter.fold (fun acc id -> Procedure.remove_block acc id) proc
+  in
+  let out_proc, id = Procedure.fresh_block out_proc ~stmts:final_edge () in
 
   (* Make this the entry and return block. *)
   let out_proc = Procedure.set_entry_block out_proc id in

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -1,8 +1,7 @@
 open Lang
 open Lang.Common
 
-(* Assumptions: SSA form probably? seems good to me! *)
-(* Also that the program is pure and lacks loops... *)
+(* Assumes program is in SSA, acyclic and pure. *)
 let construct_final_edge proc =
   (* Termination condition for each edge. *)
   let term : (IDSet.elt, Var.t) Hashtbl.t = Hashtbl.create 30 in

--- a/nix/bincaml.nix
+++ b/nix/bincaml.nix
@@ -29,6 +29,7 @@
   kittyimg,
   stb_image,
   linenoise,
+  unionFind,
 
   capstone_arm64_disas,
   aslp_lifter_ocaml,
@@ -92,6 +93,7 @@ buildDunePackage {
     patricia-tree
     logs
     mtime
+    unionFind
     terminal_size
     kittyimg
     linenoise

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -54,7 +54,7 @@ mkShell {
   ++ lib.optional stdenv.hostPlatform.isLinux perf;
 
   inputsFrom = [
-    (bincaml.overrideAttrs { doCheck = true; })
+    (bincaml.overrideAttrs { doCheck = false; })
   ];
 
   shellHook = ''

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -54,7 +54,7 @@ mkShell {
   ++ lib.optional stdenv.hostPlatform.isLinux perf;
 
   inputsFrom = [
-    (bincaml.overrideAttrs { doCheck = false; })
+    (bincaml.overrideAttrs { doCheck = true; })
   ];
 
   shellHook = ''

--- a/test/cram/cfa_reduction.il
+++ b/test/cram/cfa_reduction.il
@@ -1,0 +1,23 @@
+prog entry @f1;
+
+proc @f1(a:bv64) -> (c:bv64)
+[
+ block %a [
+  var x:bv64 := a;
+  goto(%b, %c);
+ ];
+ block %b [
+  guard(bvuge(x,0:bv64));
+  var x := bvadd(x:bv64,1:bv64);
+  goto(%exit);
+ ];
+ block %c [
+  guard(bvult(x,0:bv64));
+  var x := bvsub(x:bv64,1:bv64);
+  goto(%exit);
+ ];
+ block %exit [
+  var c:bv64 := x;
+  return;
+ ];
+];

--- a/test/cram/cfa_reduction.sexp
+++ b/test/cram/cfa_reduction.sexp
@@ -1,5 +1,5 @@
 (load-il "./cfa_reduction.il")
 (run-transforms "ssa")
 (run-transforms "cfa-reduction")
-(run-transforms "simplify")
+; (run-transforms "simplify")
 (dump-il "./out.il")

--- a/test/cram/cfa_reduction.sexp
+++ b/test/cram/cfa_reduction.sexp
@@ -3,4 +3,3 @@
 (run-transforms "cfa-reduction")
 (run-transforms "simplify")
 (dump-il "./out.il")
-

--- a/test/cram/cfa_reduction.sexp
+++ b/test/cram/cfa_reduction.sexp
@@ -1,0 +1,6 @@
+(load-il "./cfa_reduction.il")
+(run-transforms "ssa")
+(run-transforms "cfa-reduction")
+(run-transforms "simplify")
+(dump-il "./out.il")
+

--- a/test/cram/cfa_reduction.sexp
+++ b/test/cram/cfa_reduction.sexp
@@ -1,5 +1,5 @@
 (load-il "./cfa_reduction.il")
 (run-transforms "ssa")
 (run-transforms "cfa-reduction")
-; (run-transforms "simplify")
+(run-transforms "simplify")
 (dump-il "./out.il")

--- a/test/cram/cfa_reduction.t
+++ b/test/cram/cfa_reduction.t
@@ -2,7 +2,6 @@
   (load-il ./cfa_reduction.il)
   (run-transforms ssa)
   (run-transforms cfa-reduction)
-  (run-transforms simplify)
   (dump-il ./out.il)
   $ cat ./out.il
   proc @f1(a:bv64)  -> (c:bv64) {  }
@@ -10,13 +9,22 @@
   
   [
      block %block [
-       var v:bool := true;
-       guard bvult(a:bv64, 0x0:bv64);
-       guard boolnot(bvult(a:bv64, 0x0:bv64));
-       var v_2:bool := booland(v:bool, boolnot(bvult(a:bv64, 0x0:bv64)));
-       var x_6:bv64 := if v_2:bool then bvadd(a:bv64, 0x1:bv64) else bvsub(a:bv64,
-        0x1:bv64);
+       nop;
+       var x_1:bv64 := a:bv64;
+       var v:bool := booland(true);
+       nop;
+       var x_2:bv64 := x_1:bv64;
+       guard bvult(x_2:bv64, 0x0:bv64);
+       var x_3:bv64 := bvsub(x_2:bv64, 0x1:bv64);
+       var v_1:bool := booland(boolor(v:bool), bvult(x_2:bv64, 0x0:bv64));
+       nop;
+       var x_4:bv64 := x_1:bv64;
+       guard boolnot(bvult(x_4:bv64, 0x0:bv64));
+       var x_5:bv64 := bvadd(x_4:bv64, 0x1:bv64);
+       var v_2:bool := booland(boolor(v:bool), boolnot(bvult(x_4:bv64, 0x0:bv64)));
+       var x_6:bv64 := if v_2:bool then x_5:bv64 else x_3:bv64;
        var c:bv64 := x_6:bv64;
+       var v_3:bool := booland(boolor(v_2:bool, v_1:bool));
        return;
      ]
   ];

--- a/test/cram/cfa_reduction.t
+++ b/test/cram/cfa_reduction.t
@@ -2,6 +2,7 @@
   (load-il ./cfa_reduction.il)
   (run-transforms ssa)
   (run-transforms cfa-reduction)
+  (run-transforms simplify)
   (dump-il ./out.il)
   $ cat ./out.il
   proc @f1(a:bv64)  -> (c:bv64) {  }
@@ -9,22 +10,11 @@
   
   [
      block %block [
-       nop;
-       var x_1:bv64 := a:bv64;
-       var v:bool := booland(true);
-       nop;
-       var x_2:bv64 := x_1:bv64;
-       guard bvult(x_2:bv64, 0x0:bv64);
-       var x_3:bv64 := bvsub(x_2:bv64, 0x1:bv64);
-       var v_1:bool := booland(boolor(v:bool), bvult(x_2:bv64, 0x0:bv64));
-       nop;
-       var x_4:bv64 := x_1:bv64;
-       guard boolnot(bvult(x_4:bv64, 0x0:bv64));
-       var x_5:bv64 := bvadd(x_4:bv64, 0x1:bv64);
-       var v_2:bool := booland(boolor(v:bool), boolnot(bvult(x_4:bv64, 0x0:bv64)));
-       var x_6:bv64 := if v_2:bool then x_5:bv64 else x_3:bv64;
+       var v:bool := true;
+       var v_2:bool := booland(v:bool, boolnot(bvult(a:bv64, 0x0:bv64)));
+       var x_6:bv64 := if v_2:bool then bvadd(a:bv64, 0x1:bv64) else bvsub(a:bv64,
+        0x1:bv64);
        var c:bv64 := x_6:bv64;
-       var v_3:bool := booland(boolor(v_2:bool, v_1:bool));
        return;
      ]
   ];

--- a/test/cram/cfa_reduction.t
+++ b/test/cram/cfa_reduction.t
@@ -1,0 +1,2 @@
+  $ bincaml script ./cfa_reduction.sexp
+  $ cat ./out.il

--- a/test/cram/cfa_reduction.t
+++ b/test/cram/cfa_reduction.t
@@ -1,2 +1,23 @@
   $ bincaml script ./cfa_reduction.sexp
+  (load-il ./cfa_reduction.il)
+  (run-transforms ssa)
+  (run-transforms cfa-reduction)
+  (run-transforms simplify)
+  (dump-il ./out.il)
   $ cat ./out.il
+  proc @f1(a:bv64)  -> (c:bv64) {  }
+    
+  
+  [
+     block %block [
+       var v:bool := true;
+       guard bvult(a:bv64, 0x0:bv64);
+       guard boolnot(bvult(a:bv64, 0x0:bv64));
+       var v_2:bool := booland(v:bool, boolnot(bvult(a:bv64, 0x0:bv64)));
+       var x_6:bv64 := if v_2:bool then bvadd(a:bv64, 0x1:bv64) else bvsub(a:bv64,
+        0x1:bv64);
+       var c:bv64 := x_6:bv64;
+       return;
+     ]
+  ];
+  prog entry @f1;

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -62,6 +62,8 @@
   ll_spec.sexp
   repeated_ssa.il
   repeated_ssa.sexp
+  cfa_reduction.il
+  cfa_reduction.sexp
   ../../bin/main.exe))
 
 (cram


### PR DESCRIPTION
Implements the acyclic cfa reduction transform from some old snippet of nicks thesis. Basically just flattens an acyclic, deterministic procedure in a single block.
Cheats a bit because we already have an SSA transform so we can skip some of the algorithm, yay!