### PR TITLE
Use CCVector in CFA reduction to avoid quadratic

### DIFF
--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -15,17 +15,15 @@ open Expr
 
 let construct_final_edge proc =
   (* Termination condition for each edge. *)
-  let termination_condition : (IDSet.elt, Var.t) Hashtbl.t =
-    Hashtbl.create 30
-  in
+  let termination_condition : (ID.t, Var.t) Hashtbl.t = Hashtbl.create 30 in
 
   (* final_edge accumulates as one large edge containing
      all statements from existing edges with additional
      predicate variables and ite statements/assignments
-     filling in for phi-nodes. 
-  *)
-  Procedure.fold_blocks_topo_fwd
-    (fun final_edge id block ->
+     filling in for phi-nodes. *)
+  let final_edge : (Program.stmt, Vector.rw) Vector.t = CCVector.create () in
+
+  Procedure.iter_blocks_topo_fwd proc (fun (id, block) ->
       (* Compute reachability of this block. *)
       let reachable =
         match Procedure.blocks_pred proc id |> Iter.to_list with
@@ -90,8 +88,11 @@ let construct_final_edge proc =
           2. the statements for the new edge body.
           3. an assignment to the termination variable.
         *)
-      final_edge @ List.concat [ [ ites ]; non_guard_stmts; [ termination ] ])
-    [] proc
+      CCVector.push final_edge ites;
+      CCVector.append_list final_edge non_guard_stmts;
+      CCVector.push final_edge termination);
+
+  CCVector.freeze final_edge
 
 let reduce_procedure (proc : Program.proc) : Program.proc =
   (* Constructed reduced edge to replace procedure blocks. *)
@@ -101,7 +102,10 @@ let reduce_procedure (proc : Program.proc) : Program.proc =
     proc |> Procedure.iter_blocks |> Iter.map fst
     |> Iter.fold (fun acc id -> Procedure.remove_block acc id) proc
   in
-  let proc, id = Procedure.fresh_block proc ~stmts:final_edge () in
+  let proc, id = Procedure.fresh_block proc ~stmts:[] () in
+  let proc =
+    Procedure.modify_block proc id (fun b -> { b with stmts = final_edge })
+  in
 
   (* Make this the entry and return block. *)
   let proc = Procedure.set_entry_block proc id in

--- a/lib/transforms/cfa_reduction.ml
+++ b/lib/transforms/cfa_reduction.ml
@@ -21,9 +21,8 @@ let construct_final_edge proc =
      all statements from existing edges with additional
      predicate variables and ite statements/assignments
      filling in for phi-nodes. *)
-  let final_edge : (Program.stmt, Vector.rw) Vector.t = CCVector.create () in
-
-  Procedure.iter_blocks_topo_fwd proc (fun (id, block) ->
+  Procedure.fold_blocks_topo_fwd
+    (fun final_edge id block ->
       (* Compute reachability of this block. *)
       let reachable =
         match Procedure.blocks_pred proc id |> Iter.to_list with
@@ -90,9 +89,10 @@ let construct_final_edge proc =
         *)
       CCVector.push final_edge ites;
       CCVector.append_list final_edge non_guard_stmts;
-      CCVector.push final_edge termination);
-
-  CCVector.freeze final_edge
+      CCVector.push final_edge termination;
+      final_edge)
+    (CCVector.create ()) proc
+  |> CCVector.freeze
 
 let reduce_procedure (proc : Program.proc) : Program.proc =
   (* Constructed reduced edge to replace procedure blocks. *)


### PR DESCRIPTION
Follow-up to https://github.com/agle/bincaml/pull/214#pullrequestreview-4750940364

I know I said it didn't urgently need fixing, but it's just such low hanging fruit and it avoids the future frustration - however small.

In the transform, we use `modify_block` after `fresh_block` to avoid casting the vector into a list and then back to a vector.