### PR TITLE
ci: build nix packages and dev shell in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,3 +101,19 @@ jobs:
       - uses: actions/checkout@v6
       - run: opam repository --all add pac https://github.com/uq-pac/opam-repository.git
       - run: opam lint
+
+  build-nix:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: cachix/install-nix-action@v31
+
+    - run: nix build .#bincaml
+      name: Test building bincaml
+    - run: nix build .#bincaml_lsp
+      name: Test building bincaml_lsp
+    - run: nix develop .#no-fp
+      name: Test Nix dev shell
+

--- a/test/cram/logs.t
+++ b/test/cram/logs.t
@@ -10,7 +10,7 @@ Logs should print conditionally on whether their source has the right level.
   (log-level info)
   (log-level info analysis.irreducible_loops)
   (run-transforms irreducible-loops)
-  bincaml: [INFO] found 15 loops, 1 irreducible
+  bincaml: [INFO] found 15 loops, 1 irreduciblea
   bincaml: [INFO] found 0 loops, 0 irreducible
 
 

--- a/test/cram/logs.t
+++ b/test/cram/logs.t
@@ -10,7 +10,7 @@ Logs should print conditionally on whether their source has the right level.
   (log-level info)
   (log-level info analysis.irreducible_loops)
   (run-transforms irreducible-loops)
-  bincaml: [INFO] found 15 loops, 1 irreduciblea
+  bincaml: [INFO] found 15 loops, 1 irreducible
   bincaml: [INFO] found 0 loops, 0 irreducible
 
 


### PR DESCRIPTION
Closes https://github.com/agle/bincaml/issues/209

As long as we don't mark it as a Required check, it will still be possible to merge PRs without the Nix build succeeding. This just makes it much more visible if it does break.