### PR TITLE
hm: avoid `include` and call `fix` in smart constructors 

### DIFF
--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -5,7 +5,7 @@ open Abstract_expr
 
 module TypeInference (T : TypeExpr.TypeContext) = struct
   open Hm_types.Make (T)
-  open Unification.Make (T)
+  open Unification.Make (T) (Hm_types.Make (T))
   open Inference.Make (T)
   open Solve_bv.Make (T)
   open T

--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -5,7 +5,7 @@ open Abstract_expr
 
 module TypeInference (T : TypeExpr.TypeContext) = struct
   open Hm_types.Make (T)
-  open Unification.Make (T) (Hm_types.Make (T))
+  open Unification.Make (T)
   open Inference.Make (T)
   open Solve_bv.Make (T)
   open T

--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -85,7 +85,7 @@ module TypeInference (T : TypeExpr.TypeContext) = struct
       List.map
         (fun a ->
           let a = infer_expr vc ~univ [%here] a ctx in
-          let _ = unify (fix bool_type) (getty a) in
+          let _ = unify bool_type (getty a) in
           a)
         b
     in
@@ -155,9 +155,8 @@ module TypeInference (T : TypeExpr.TypeContext) = struct
           let binding s = retype_var global_universe s binding in
           match definition with
           | Axiom b ->
-              let bt = fix bool_type in
               let b = infer_expr ~univ:global_universe [%here] b scheme in
-              let _ = unify (getty b) bt in
+              let _ = unify (getty b) bool_type in
               let new_axiom scheme =
                 Function
                   {

--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -4,7 +4,10 @@ open Abstract_expr
 (** Hindley-Milner type inference based on a union-find. *)
 
 module TypeInference (T : TypeExpr.TypeContext) = struct
-  include Inference.Make (T)
+  open Hm_types.Make (T)
+  open Unification.Make (T)
+  open Inference.Make (T)
+  open Solve_bv.Make (T)
 
   let retype_var univ ctx id =
     lookup_var_typ ~no_constraint:true univ ctx id |> find |> to_basil
@@ -20,16 +23,17 @@ module TypeInference (T : TypeExpr.TypeContext) = struct
       p
 
   let ctx_to_string ctx =
-    TCtx.to_iter ctx
+    TypeExpr.TCtx.to_iter ctx
     |> Iter.to_string (fun (a, b) ->
-        Printf.sprintf "%s %s" (V.to_string a) (scheme_to_string b))
+        Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
 
   let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
   let unfix i = match i with Expr.BasilExpr.E i -> i
   let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
 
   (** Extract type after full inference has run. *)
-  let elaborate_expr ~univ (hr : Lexing.position) e (c : scheme TCtx.t) =
+  let elaborate_expr ~univ (hr : Lexing.position) e (c : scheme TypeExpr.TCtx.t)
+      =
     let alg e =
       let e =
         match e with
@@ -63,7 +67,7 @@ module TypeInference (T : TypeExpr.TypeContext) = struct
     let globs = Var.Decls.values (Procedure.local_decls p) in
     let formals_in = Procedure.formal_in_params p |> StringMap.values in
     let formals_out = Procedure.formal_out_params p |> StringMap.values in
-    let univ = V.proc_univ @@ Procedure.id p in
+    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
     let ctx =
       Iter.fold
         (decl_var_typ ~no_constraint univ)
@@ -74,7 +78,7 @@ module TypeInference (T : TypeExpr.TypeContext) = struct
 
   let infer_proc vc prog ctx ?(no_constraint = false) (p : Program.proc) =
     let spec = Procedure.specification p in
-    let univ = V.proc_univ @@ Procedure.id p in
+    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
     let ibool_list b =
       List.map
         (fun a ->
@@ -222,7 +226,8 @@ module TypeInference (T : TypeExpr.TypeContext) = struct
     functions, which take the final inference context and convert the HM-typed
     expressions back to bincaml typed expressions. *)
     let scheme, new_decls =
-      decls |> List.fold_map (infer_decl visit_constraint prog) TCtx.empty
+      decls
+      |> List.fold_map (infer_decl visit_constraint prog) TypeExpr.TCtx.empty
     in
     let _ = solve_constraints ~max_iters:50 !constraints in
     (* TODO: implicit decls; constructors need to be added after the types they

--- a/lib/lang/hm/elaboration.ml
+++ b/lib/lang/hm/elaboration.ml
@@ -8,6 +8,8 @@ module TypeInference (T : TypeExpr.TypeContext) = struct
   open Unification.Make (T)
   open Inference.Make (T)
   open Solve_bv.Make (T)
+  open T
+  open T.Typ
 
   let retype_var univ ctx id =
     lookup_var_typ ~no_constraint:true univ ctx id |> find |> to_basil

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -148,7 +148,7 @@ open Abstract_expr
 module Hm_make_fresh () = struct
   module Ctx = TypeExpr.MakeFresh ()
   include Hm_types.Make (Ctx)
-  include Unification.Make (Ctx) (Hm_types.Make (Ctx))
+  include Unification.Make (Ctx)
   include Inference.Make (Ctx)
   include Solve_bv.Make (Ctx)
   include Elaboration.TypeInference (Ctx)

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -11,6 +11,8 @@
     - {:https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Algorithm_J}
     - {:https://bernsteinbear.com/blog/type-inference/} *)
 
+module State = State
+
 module TypeExpr = TypeExpr
 (** {1 Type Expressions}
 

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -148,7 +148,7 @@ open Abstract_expr
 module Hm_make_fresh () = struct
   module Ctx = TypeExpr.MakeFresh ()
   include Hm_types.Make (Ctx)
-  include Unification.Make (Ctx)
+  include Unification.Make (Ctx) (Hm_types.Make (Ctx))
   include Inference.Make (Ctx)
   include Solve_bv.Make (Ctx)
   include Elaboration.TypeInference (Ctx)

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -145,6 +145,15 @@ module Elaboration = Elaboration
 open Common
 open Abstract_expr
 
+module Hm_make_fresh () = struct
+  module Ctx = TypeExpr.MakeFresh ()
+  include Hm_types.Make (Ctx)
+  include Unification.Make (Ctx)
+  include Inference.Make (Ctx)
+  include Solve_bv.Make (Ctx)
+  include Elaboration.TypeInference (Ctx)
+end
+
 (*
    TODO:
 
@@ -165,7 +174,7 @@ open Abstract_expr
 let locally_elaborate_expr (e : Expr.BasilExpr.t) =
   let open AbstractExpr in
   let open Ops.AllOps in
-  let module T = Elaboration.TypeInference (TypeExpr.MakeFresh ()) in
+  let module T = Hm_make_fresh () in
   let constraints = ref [] in
   let univ = "<expr local>" in
   let ctx =
@@ -188,7 +197,7 @@ let elaborated_type_alg (e : Types.t Expr.BasilExpr.abstract_expr) =
 (** Partially apply args list to function type funtype and return resulting type
 *)
 let type_applied (funtype : Types.t) (args : Types.t list) =
-  let module T = Elaboration.TypeInference (TypeExpr.MakeFresh ()) in
+  let module T = Hm_make_fresh () in
   let rt = T.fresh_tvar ~n:"ret" () in
   let args = List.map T.ty_of_basil args in
 
@@ -204,6 +213,6 @@ let type_applied (funtype : Types.t) (args : Types.t list) =
 let elaborate_prog prog =
   (* We need to create a local typing module in order to get fresh state for the
   union find and hash cons. *)
-  let module T = Elaboration.TypeInference (TypeExpr.MakeFresh ()) in
+  let module T = Hm_make_fresh () in
   let scheme, prog = T.infer_program prog in
   prog

--- a/lib/lang/hm/hm.ml
+++ b/lib/lang/hm/hm.ml
@@ -11,8 +11,6 @@
     - {:https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#Algorithm_J}
     - {:https://bernsteinbear.com/blog/type-inference/} *)
 
-module State = State
-
 module TypeExpr = TypeExpr
 (** {1 Type Expressions}
 

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -5,68 +5,64 @@ open Abstract_expr
 
 exception TypeErr of string
 
-module Make (T : TypeExpr.TypeContext) = struct
-  module Ctx = T
-  include Ctx
-  include TypeExpr
-  include Typ
-
-  type typ = T.Typ.t [@@deriving eq, ord]
+module Make (Ctx : TypeExpr.TypeContext) = struct
+  type typ = Ctx.Typ.t [@@deriving eq, ord]
 
   (** Recursion algebra for printing types *)
   let printer_alg = function
-    | Var e -> ID.to_string e
+    | TypeExpr.ATyp.Var e -> ID.to_string e
     | TypeConstr ([ l ], e) -> l ^ " " ^ e
     | TypeConstr ([ a; b ], "->") -> a ^ " -> " ^ b
     | TypeConstr ([], e) -> e
     | TypeConstr (ls, e) ->
         List.to_string ~start:"(" ~stop:")" ~sep:"," Fun.id ls ^ " " ^ e
 
-  let type_to_string t = Rec.cata printer_alg t
+  let type_to_string t = Ctx.Rec.cata printer_alg t
 
   let plpos (l : Lexing.position) =
     Printf.sprintf "%s:%d" l.pos_fname l.pos_lnum
 
   (** Type schemes; how values of the typing context are typed. *)
-  type scheme = Forall of tvar list * t
+  type scheme = Forall of TypeExpr.tvar list * Ctx.Typ.t
 
   let scheme_to_string = function
     | Forall (tl, t) ->
-        List.to_string ID.to_string tl ^ ". " ^ type_to_string (find t)
+        List.to_string ID.to_string tl ^ ". " ^ type_to_string (Ctx.Typ.find t)
 
   (** Function type, takes two arguments: we always curry. *)
-  let fun_type a b = TypeConstr ([ a; b ], "->")
+  let fun_type a b = TypeExpr.ATyp.TypeConstr ([ a; b ], "->")
 
   (** A type representing a number *)
   let nat_val_type i =
-    let num = fix (TypeConstr ([], Int.to_string i)) in
-    TypeConstr ([ num ], "ℕ")
+    let num = Ctx.Typ.fix (TypeExpr.ATyp.TypeConstr ([], Int.to_string i)) in
+    Ctx.Typ.TypeConstr ([ num ], "ℕ")
 
-  let is_nat_val_type (i : t) =
-    match unfix i with
+  let is_nat_val_type (i : Ctx.Typ.t) =
+    match Ctx.Typ.unfix i with
     | TypeConstr ([ num ], "ℕ") -> (
-        match unfix num with
+        match Ctx.Typ.unfix num with
         | TypeConstr ([], num) -> Int.of_string num
         | _ -> None)
     | _ -> None
 
   (** A bitvector type parametric in its width *)
-  let bv_type i = map_expr fix @@ TypeConstr ([ nat_val_type i ], "bv")
+  let bv_type i =
+    Ctx.Typ.(map_expr fix @@ TypeConstr ([ nat_val_type i ], "bv"))
 
   (** Bitvector of arbitrary size *)
-  let bvunk i = TypeConstr ([ i ], "bv")
+  let bvunk i = Ctx.Typ.TypeConstr ([ i ], "bv")
 
   (** {2 Primitive types} *)
 
-  let int_type = TypeConstr ([], "int")
-  let bool_type = TypeConstr ([], "bool")
-  let unit_t = TypeConstr ([], "unit")
-  let top_t = TypeConstr ([], "top")
-  let nothing_t = TypeConstr ([], "nothing")
-  let ptr_typ_sub a b = TypeConstr ([ a; b ], "ptr")
+  let int_type = Ctx.Typ.TypeConstr ([], "int")
+  let bool_type = Ctx.Typ.TypeConstr ([], "bool")
+  let unit_t = Ctx.Typ.TypeConstr ([], "unit")
+  let top_t = Ctx.Typ.TypeConstr ([], "top")
+  let nothing_t = Ctx.Typ.TypeConstr ([], "nothing")
+  let ptr_typ_sub a b = Ctx.Typ.TypeConstr ([ a; b ], "ptr")
   let ptr_typ = bv_type 64
 
-  let rec to_basil (t : t) : Types.t =
+  let rec to_basil (t : Ctx.Typ.t) : Types.t =
     let wrapped t f =
       try f ()
       with TypeErr e ->
@@ -74,7 +70,7 @@ module Make (T : TypeExpr.TypeContext) = struct
     in
     let open Types in
     wrapped t @@ fun () ->
-    match unfix t with
+    match Ctx.Typ.unfix t with
     | TypeConstr ([ a; b ], "->") ->
         let a = wrapped a @@ fun () -> to_basil a in
         let b = wrapped b @@ fun () -> to_basil b in
@@ -91,7 +87,7 @@ module Make (T : TypeExpr.TypeContext) = struct
     | TypeConstr ([], o) -> Sort (o, [])
     | _ -> failwith "not impl"
 
-  let rec ty_of_basil (t : Types.t) : t =
+  let rec ty_of_basil (t : Types.t) : Ctx.Typ.t =
     let e =
       match t with
       | Types.Boolean -> bool_type
@@ -105,16 +101,24 @@ module Make (T : TypeExpr.TypeContext) = struct
       | Types.Struct _ -> failwith "unsupp"
       | Types.Pointer { lower; upper } ->
           ptr_typ_sub (ty_of_basil lower) (ty_of_basil upper)
-      | Types.Variable n -> Var (gen.fresh ~name:n ())
+      | Types.Variable n -> Var (Ctx.gen.fresh ~name:n ())
     in
-    fix e
+    Ctx.Typ.fix e
 
-  let curry (args : t expr list) (v : t expr) =
-    List.fold_left (fun a p -> fix @@ fun_type (fix p) a) (fix v) args
+  let curry (args : Ctx.Typ.t TypeExpr.ATyp.expr list)
+      (v : Ctx.Typ.t TypeExpr.ATyp.expr) =
+    List.fold_left
+      (fun a p -> Ctx.Typ.fix @@ fun_type (Ctx.Typ.fix p) a)
+      (Ctx.Typ.fix v) args
 
-  let curry_f (args : t list) (v : t) =
-    List.fold_left (fun a p -> fix @@ fun_type p a) v args
+  let curry_f (args : Ctx.Typ.t list) (v : Ctx.Typ.t) =
+    List.fold_left (fun a p -> Ctx.Typ.fix @@ fun_type p a) v args
 
   let types_universe = "<types>"
   let global_universe = "<global>"
+
+  include Ctx
+  (** XXX: TODO........... *)
+
+  include Typ
 end

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -116,9 +116,4 @@ module Make (Ctx : TypeExpr.TypeContext) = struct
 
   let types_universe = "<types>"
   let global_universe = "<global>"
-
-  include Ctx
-  (** XXX: TODO........... *)
-
-  include Typ
 end

--- a/lib/lang/hm/hm_types.ml
+++ b/lib/lang/hm/hm_types.ml
@@ -30,12 +30,12 @@ module Make (Ctx : TypeExpr.TypeContext) = struct
         List.to_string ID.to_string tl ^ ". " ^ type_to_string (Ctx.Typ.find t)
 
   (** Function type, takes two arguments: we always curry. *)
-  let fun_type a b = TypeExpr.ATyp.TypeConstr ([ a; b ], "->")
+  let fun_type a b = Ctx.Typ.fix (TypeConstr ([ a; b ], "->"))
 
   (** A type representing a number *)
   let nat_val_type i =
     let num = Ctx.Typ.fix (TypeExpr.ATyp.TypeConstr ([], Int.to_string i)) in
-    Ctx.Typ.TypeConstr ([ num ], "ℕ")
+    Ctx.Typ.fix (TypeConstr ([ num ], "ℕ"))
 
   let is_nat_val_type (i : Ctx.Typ.t) =
     match Ctx.Typ.unfix i with
@@ -46,20 +46,19 @@ module Make (Ctx : TypeExpr.TypeContext) = struct
     | _ -> None
 
   (** A bitvector type parametric in its width *)
-  let bv_type i =
-    Ctx.Typ.(map_expr fix @@ TypeConstr ([ nat_val_type i ], "bv"))
+  let bv_type i = Ctx.Typ.fix (TypeConstr ([ nat_val_type i ], "bv"))
 
   (** Bitvector of arbitrary size *)
-  let bvunk i = Ctx.Typ.TypeConstr ([ i ], "bv")
+  let bvunk i = Ctx.Typ.fix (TypeConstr ([ i ], "bv"))
 
   (** {2 Primitive types} *)
 
-  let int_type = Ctx.Typ.TypeConstr ([], "int")
-  let bool_type = Ctx.Typ.TypeConstr ([], "bool")
-  let unit_t = Ctx.Typ.TypeConstr ([], "unit")
-  let top_t = Ctx.Typ.TypeConstr ([], "top")
-  let nothing_t = Ctx.Typ.TypeConstr ([], "nothing")
-  let ptr_typ_sub a b = Ctx.Typ.TypeConstr ([ a; b ], "ptr")
+  let int_type = Ctx.Typ.fix (TypeConstr ([], "int"))
+  let bool_type = Ctx.Typ.fix (TypeConstr ([], "bool"))
+  let unit_t = Ctx.Typ.fix (TypeConstr ([], "unit"))
+  let top_t = Ctx.Typ.fix (TypeConstr ([], "top"))
+  let nothing_t = Ctx.Typ.fix (TypeConstr ([], "nothing"))
+  let ptr_typ_sub a b = Ctx.Typ.fix (TypeConstr ([ a; b ], "ptr"))
   let ptr_typ = bv_type 64
 
   let rec to_basil (t : Ctx.Typ.t) : Types.t =
@@ -88,31 +87,26 @@ module Make (Ctx : TypeExpr.TypeContext) = struct
     | _ -> failwith "not impl"
 
   let rec ty_of_basil (t : Types.t) : Ctx.Typ.t =
-    let e =
-      match t with
-      | Types.Boolean -> bool_type
-      | Types.Integer -> int_type
-      | Types.Bitvector i -> bv_type i
-      | Types.Unit -> unit_t
-      | Types.Top -> top_t
-      | Types.Nothing -> nothing_t
-      | Types.Map (a, b) -> fun_type (ty_of_basil a) (ty_of_basil b)
-      | Types.Sort (n, _) -> TypeConstr ([], n)
-      | Types.Struct _ -> failwith "unsupp"
-      | Types.Pointer { lower; upper } ->
-          ptr_typ_sub (ty_of_basil lower) (ty_of_basil upper)
-      | Types.Variable n -> Var (Ctx.gen.fresh ~name:n ())
-    in
-    Ctx.Typ.fix e
+    match t with
+    | Types.Boolean -> bool_type
+    | Types.Integer -> int_type
+    | Types.Bitvector i -> bv_type i
+    | Types.Unit -> unit_t
+    | Types.Top -> top_t
+    | Types.Nothing -> nothing_t
+    | Types.Map (a, b) -> fun_type (ty_of_basil a) (ty_of_basil b)
+    | Types.Sort (n, _) -> Ctx.Typ.fix (TypeConstr ([], n))
+    | Types.Struct _ -> failwith "unsupp"
+    | Types.Pointer { lower; upper } ->
+        ptr_typ_sub (ty_of_basil lower) (ty_of_basil upper)
+    | Types.Variable n -> Ctx.Typ.fix (Var (Ctx.gen.fresh ~name:n ()))
 
   let curry (args : Ctx.Typ.t TypeExpr.ATyp.expr list)
       (v : Ctx.Typ.t TypeExpr.ATyp.expr) =
-    List.fold_left
-      (fun a p -> Ctx.Typ.fix @@ fun_type (Ctx.Typ.fix p) a)
-      (Ctx.Typ.fix v) args
+    List.fold_left (fun a p -> fun_type (Ctx.Typ.fix p) a) (Ctx.Typ.fix v) args
 
   let curry_f (args : Ctx.Typ.t list) (v : Ctx.Typ.t) =
-    List.fold_left (fun a p -> Ctx.Typ.fix @@ fun_type p a) v args
+    List.fold_left (fun a p -> fun_type p a) v args
 
   let types_universe = "<types>"
   let global_universe = "<global>"

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -4,358 +4,340 @@ open Hm_types
 
 (** Hindley-Milner type inference based on a union-find. *)
 
-module Make
-    (T : TypeExpr.TypeContext)
-    (Hm_types' :
-      module type of Hm_types.Make (T))
-        (Unification' :
-          module type of Unification.Make (T))
-            (Hm_types' : module type of Hm_types.Make (T)) =
-        struct
-      open Hm_types.Make (T)
-      open Unification.Make (T) (Hm_types.Make (T))
-      open Solve_bv.Make (T)
-      open T
-      open T.Typ
+module Make (T : TypeExpr.TypeContext) = struct
+  open Solve_bv.Make (T)
+  open Hm_types.Make (T)
+  open Unification.Make (T)
+  open T
+  open T.Typ
 
-      (** An AbstractExpr.t with [t] used as the type. *)
-      module AbsTypingExpr = struct
-        open Ops
-        include AllOps
-        module Var = Var
+  (** An AbstractExpr.t with [t] used as the type. *)
+  module AbsTypingExpr = struct
+    open Ops
+    include AllOps
+    module Var = Var
 
-        type var = Var.t
+    type var = Var.t
 
-        type t =
-          | E of (const, Var.t, unary, binary, intrin, typ, t) AbstractExpr.t
-        [@@unboxed] [@@deriving eq, ord]
+    type t = E of (const, Var.t, unary, binary, intrin, typ, t) AbstractExpr.t
+    [@@unboxed] [@@deriving eq, ord]
 
-        type nonrec typ = typ
+    type nonrec typ = typ
 
-        let top_typ = top_t
-        let fix i = E i
-        let unfix i = match i with E i -> i
+    let top_typ = top_t
+    let fix i = E i
+    let unfix i = match i with E i -> i
+  end
+
+  module TypingExpr = Expr.Make (AbsTypingExpr)
+
+  let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
+
+  let infer_var univ ctx id =
+    let typ = lookup_var_typ univ ctx id in
+    (id, typ)
+
+  (** Return the generic type scheme for an op. We generalise the type, and hope
+      dearly that a concrete type is found by inference.
+
+      TODO: some approach like weak type variables that makes it a type error to
+      fail to instantiate. *)
+  let scheme_of_op ~visit_constraint (gen : ID.generator)
+      (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
+    let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
+    match o with
+    | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
+    | `SignExtend bits ->
+        let a = fv () in
+        let equ = fv () in
+        let r = curry_f [ bvunk a ] (bvunk equ) in
+        visit_constraint @@ AddConst { a; b = bits; equ };
+        r
+    | `ZeroExtend bits ->
+        let a = fv () and equ = fv () in
+        visit_constraint @@ AddConst { a; b = bits; equ };
+        curry_f [ bvunk a ] (bvunk equ)
+    | `BOOLTOBV1 -> curry_f [ bool_type ] (bv_type 1)
+    | `Bitvector b -> bv_type (Bitvec.size b)
+    | #Ops.BVOps.binary_unif ->
+        let a = fv () in
+        curry_f [ bvunk a; bvunk a ] (bvunk a)
+    | #Ops.BVOps.binary_pred ->
+        let a = fv () in
+        curry_f [ bvunk a; bvunk a ] bool_type
+    | #Ops.BVOps.unary_unif ->
+        let a = fv () in
+        curry_f [ bvunk a ] (bvunk a)
+    | `INTNEG -> curry_f [ int_type ] int_type
+    | #Ops.IntOps.binary_pred -> curry_f [ int_type; int_type ] bool_type
+    | #Ops.IntOps.const -> int_type
+    | #Ops.IntOps.binary_unif -> curry_f [ int_type; int_type ] int_type
+    | #Ops.LogicalOps.binary -> curry_f [ bool_type; bool_type ] bool_type
+    | #Ops.LogicalOps.unary -> curry_f [ bool_type ] bool_type
+    | #Ops.LogicalOps.const -> bool_type
+    | `Old ->
+        let a = fv () in
+        curry_f [ a ] a
+    | #Ops.AllOps.binary as o ->
+        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+    | #Ops.AllOps.unary as o ->
+        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+    | #Ops.AllOps.const as o ->
+        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+
+  (** return the generic type scheme of an intrinsic operation *)
+  let scheme_of_intrin ?(visit_constraint = fun a -> ()) (gen : ID.generator)
+      (o : Ops.AllOps.intrin) args =
+    let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
+    match o with
+    | `BVADD | `BVMUL | `BVOR | `BVXOR | `BVAND ->
+        let a = fv () in
+        curry_f (List.init args (fun _ -> a)) a
+    | `BVConcat ->
+        let args = List.init args (fun _ -> fv ()) in
+        let rs =
+          List.reduce_exn
+            (fun a b ->
+              let equ = fv () in
+              visit_constraint (Add { a; b; equ });
+              equ)
+            args
+        in
+        let rs = bvunk rs in
+        let args = List.map bvunk args in
+        curry_f args rs
+    | `OR | `AND -> curry_f (List.init args (fun _ -> bool_type)) bool_type
+    | `MapUpdate ->
+        let a = fv () in
+        let b = fv () in
+        let m = curry_f [ a ] b in
+        curry_f [ m; a; b ] m
+    | `Cases -> fv ()
+
+  let do_infer ~visit_constraint
+      (infer :
+        univ:string ->
+        Lexing.position ->
+        Program.e ->
+        scheme TypeExpr.TCtx.t ->
+        AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
+    let mkv v = TypeExpr.V.of_var univ v in
+    let r = fix @@ Var (gen.fresh ()) in
+    let open Abstract_expr.AbstractExpr in
+    let e = Expr.BasilExpr.unfix e in
+    let e = set_typ e r in
+    match e with
+    | RVar { id; attrib } ->
+        let typ = lookup_var_typ univ c id in
+        AbsTypingExpr.fix (RVar { attrib; id; typ })
+    | Lambda { op; bound_vars; in_body; attrib; triggers } -> begin
+        let tvars = List.map (fun v -> (v, inst_annot_v v)) bound_vars in
+        let ictx =
+          List.map (fun (v, t) -> (mkv v, Forall ([], t))) tvars
+          |> TypeExpr.TCtx.add_list c
+        in
+        let bdty = infer ~univ [%here] in_body ictx in
+        let typ =
+          match op with
+          | `Lambda -> getty bdty
+          | `Forall | `Exists -> unify (getty bdty) bool_type
+        in
+        ignore @@ unify r (curry_f (List.map snd tvars) (getty bdty));
+        let triggers =
+          List.map (List.map (fun e -> infer ~univ [%here] e ictx)) triggers
+        in
+        AbsTypingExpr.fix
+          (Lambda { op; bound_vars; in_body = bdty; attrib; typ; triggers })
       end
+    | Constant { const = #Ops.AllOps.const as op; attrib } -> begin
+        let f = scheme_of_op ~visit_constraint gen op in
+        let r = unify r f in
+        AbsTypingExpr.fix (Constant { typ = r; const = op; attrib })
+      end
+    | UnaryExpr { op = #Ops.AllOps.unary as op; arg; attrib } -> begin
+        let f = scheme_of_op ~visit_constraint gen op in
+        let arg = infer ~univ [%here] arg c in
+        ignore @@ unify f (curry_f [ getty arg ] r);
+        AbsTypingExpr.fix (UnaryExpr { typ = r; op; attrib; arg })
+      end
+    | BinaryExpr { op = #Ops.AllOps.binary as op; arg1; arg2; attrib } -> begin
+        let f = scheme_of_op ~visit_constraint gen op in
+        let arg1 = infer ~univ [%here] arg1 c in
+        let arg2 = infer ~univ [%here] arg2 c in
+        ignore @@ unify f (curry_f [ getty arg1; getty arg2 ] r);
+        AbsTypingExpr.fix (BinaryExpr { typ = r; op; attrib; arg1; arg2 })
+      end
+    | ApplyIntrin { op = #Ops.AllOps.intrin as op; args; attrib } -> begin
+        let f = scheme_of_intrin ~visit_constraint gen op (List.length args) in
+        let args = List.map (fun a -> infer ~univ [%here] a c) args in
+        ignore @@ unify f (curry_f (List.map getty args) r);
+        AbsTypingExpr.fix (ApplyIntrin { typ = r; op; attrib; args })
+      end
+    | ApplyFun { func; args; attrib } ->
+        let f = infer ~univ [%here] func c in
+        let args = List.map (fun a -> infer ~univ [%here] a c) args in
+        ignore @@ unify (getty f) (curry_f (List.map getty args) r);
+        AbsTypingExpr.fix (ApplyFun { typ = r; func = f; attrib; args })
+    | Let _ -> failwith ""
 
-      module TypingExpr = Expr.Make (AbsTypingExpr)
+  let rec infer_expr visit_constraint ~univ (hr : Lexing.position) e =
+   fun (c : scheme TypeExpr.TCtx.t) ->
+    Logs.debug (fun m ->
+        m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
+    let t =
+      try do_infer ~visit_constraint (infer_expr visit_constraint) univ hr e c
+      with TypeErr m ->
+        raise (TypeErr (m ^ " : " ^ Expr.BasilExpr.to_string e))
+    in
+    t
 
-      let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
+  let infer visit_constraint ~univ (hr : Lexing.position) e
+      (c : scheme TypeExpr.TCtx.t) =
+    let nexpr =
+      infer_expr visit_constraint ~univ hr e c
+      |> AbsTypingExpr.unfix |> AbstractExpr.get_typ
+    in
+    nexpr
 
-      let infer_var univ ctx id =
-        let typ = lookup_var_typ univ ctx id in
-        (id, typ)
+  let unfix i = match i with Expr.BasilExpr.E i -> i
+  let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
 
-      (** Return the generic type scheme for an op. We generalise the type, and
-          hope dearly that a concrete type is found by inference.
-
-          TODO: some approach like weak type variables that makes it a type
-          error to fail to instantiate. *)
-      let scheme_of_op ~visit_constraint (gen : ID.generator)
-          (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
-        let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
-        match o with
-        | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
-        | `SignExtend bits ->
-            let a = fv () in
-            let equ = fv () in
-            let r = curry_f [ bvunk a ] (bvunk equ) in
-            visit_constraint @@ AddConst { a; b = bits; equ };
-            r
-        | `ZeroExtend bits ->
-            let a = fv () and equ = fv () in
-            visit_constraint @@ AddConst { a; b = bits; equ };
-            curry_f [ bvunk a ] (bvunk equ)
-        | `BOOLTOBV1 -> curry_f [ bool_type ] (bv_type 1)
-        | `Bitvector b -> bv_type (Bitvec.size b)
-        | #Ops.BVOps.binary_unif ->
-            let a = fv () in
-            curry_f [ bvunk a; bvunk a ] (bvunk a)
-        | #Ops.BVOps.binary_pred ->
-            let a = fv () in
-            curry_f [ bvunk a; bvunk a ] bool_type
-        | #Ops.BVOps.unary_unif ->
-            let a = fv () in
-            curry_f [ bvunk a ] (bvunk a)
-        | `INTNEG -> curry_f [ int_type ] int_type
-        | #Ops.IntOps.binary_pred -> curry_f [ int_type; int_type ] bool_type
-        | #Ops.IntOps.const -> int_type
-        | #Ops.IntOps.binary_unif -> curry_f [ int_type; int_type ] int_type
-        | #Ops.LogicalOps.binary -> curry_f [ bool_type; bool_type ] bool_type
-        | #Ops.LogicalOps.unary -> curry_f [ bool_type ] bool_type
-        | #Ops.LogicalOps.const -> bool_type
-        | `Old ->
-            let a = fv () in
-            curry_f [ a ] a
-        | #Ops.AllOps.binary as o ->
-            failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-        | #Ops.AllOps.unary as o ->
-            failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-        | #Ops.AllOps.const as o ->
-            failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-
-      (** return the generic type scheme of an intrinsic operation *)
-      let scheme_of_intrin ?(visit_constraint = fun a -> ())
-          (gen : ID.generator) (o : Ops.AllOps.intrin) args =
-        let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
-        match o with
-        | `BVADD | `BVMUL | `BVOR | `BVXOR | `BVAND ->
-            let a = fv () in
-            curry_f (List.init args (fun _ -> a)) a
-        | `BVConcat ->
-            let args = List.init args (fun _ -> fv ()) in
-            let rs =
-              List.reduce_exn
-                (fun a b ->
-                  let equ = fv () in
-                  visit_constraint (Add { a; b; equ });
-                  equ)
-                args
-            in
-            let rs = bvunk rs in
-            let args = List.map bvunk args in
-            curry_f args rs
-        | `OR | `AND -> curry_f (List.init args (fun _ -> bool_type)) bool_type
-        | `MapUpdate ->
-            let a = fv () in
-            let b = fv () in
-            let m = curry_f [ a ] b in
-            curry_f [ m; a; b ] m
-        | `Cases -> fv ()
-
-      let do_infer ~visit_constraint
-          (infer :
-            univ:string ->
-            Lexing.position ->
-            Program.e ->
-            scheme TypeExpr.TCtx.t ->
-            AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
-        let mkv v = TypeExpr.V.of_var univ v in
-        let r = fix @@ Var (gen.fresh ()) in
-        let open Abstract_expr.AbstractExpr in
-        let e = Expr.BasilExpr.unfix e in
-        let e = set_typ e r in
-        match e with
-        | RVar { id; attrib } ->
-            let typ = lookup_var_typ univ c id in
-            AbsTypingExpr.fix (RVar { attrib; id; typ })
-        | Lambda { op; bound_vars; in_body; attrib; triggers } -> begin
-            let tvars = List.map (fun v -> (v, inst_annot_v v)) bound_vars in
-            let ictx =
-              List.map (fun (v, t) -> (mkv v, Forall ([], t))) tvars
-              |> TypeExpr.TCtx.add_list c
-            in
-            let bdty = infer ~univ [%here] in_body ictx in
-            let typ =
-              match op with
-              | `Lambda -> getty bdty
-              | `Forall | `Exists -> unify (getty bdty) bool_type
-            in
-            ignore @@ unify r (curry_f (List.map snd tvars) (getty bdty));
-            let triggers =
-              List.map (List.map (fun e -> infer ~univ [%here] e ictx)) triggers
-            in
-            AbsTypingExpr.fix
-              (Lambda { op; bound_vars; in_body = bdty; attrib; typ; triggers })
-          end
-        | Constant { const = #Ops.AllOps.const as op; attrib } -> begin
-            let f = scheme_of_op ~visit_constraint gen op in
-            let r = unify r f in
-            AbsTypingExpr.fix (Constant { typ = r; const = op; attrib })
-          end
-        | UnaryExpr { op = #Ops.AllOps.unary as op; arg; attrib } -> begin
-            let f = scheme_of_op ~visit_constraint gen op in
-            let arg = infer ~univ [%here] arg c in
-            ignore @@ unify f (curry_f [ getty arg ] r);
-            AbsTypingExpr.fix (UnaryExpr { typ = r; op; attrib; arg })
-          end
-        | BinaryExpr { op = #Ops.AllOps.binary as op; arg1; arg2; attrib } ->
-          begin
-            let f = scheme_of_op ~visit_constraint gen op in
-            let arg1 = infer ~univ [%here] arg1 c in
-            let arg2 = infer ~univ [%here] arg2 c in
-            ignore @@ unify f (curry_f [ getty arg1; getty arg2 ] r);
-            AbsTypingExpr.fix (BinaryExpr { typ = r; op; attrib; arg1; arg2 })
-          end
-        | ApplyIntrin { op = #Ops.AllOps.intrin as op; args; attrib } -> begin
-            let f =
-              scheme_of_intrin ~visit_constraint gen op (List.length args)
-            in
-            let args = List.map (fun a -> infer ~univ [%here] a c) args in
-            ignore @@ unify f (curry_f (List.map getty args) r);
-            AbsTypingExpr.fix (ApplyIntrin { typ = r; op; attrib; args })
-          end
-        | ApplyFun { func; args; attrib } ->
-            let f = infer ~univ [%here] func c in
-            let args = List.map (fun a -> infer ~univ [%here] a c) args in
-            ignore @@ unify (getty f) (curry_f (List.map getty args) r);
-            AbsTypingExpr.fix (ApplyFun { typ = r; func = f; attrib; args })
-        | Let _ -> failwith ""
-
-      let rec infer_expr visit_constraint ~univ (hr : Lexing.position) e =
-       fun (c : scheme TypeExpr.TCtx.t) ->
-        Logs.debug (fun m ->
-            m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
-        let t =
-          try
-            do_infer ~visit_constraint (infer_expr visit_constraint) univ hr e c
-          with TypeErr m ->
-            raise (TypeErr (m ^ " : " ^ Expr.BasilExpr.to_string e))
+  let infer_phi visit_constraint univ ctx (p : Var.t Block.phi list) =
+    let infer = infer visit_constraint in
+    let open Block in
+    let r = fix @@ Var (gen.fresh ()) in
+    List.fold_left
+      (fun acc { lhs; rhs } ->
+        let lhs = infer [%here] ~univ (Expr.BasilExpr.rvar lhs) ctx in
+        let e =
+          List.fold_left
+            (fun a (_, r) ->
+              let r = infer [%here] ~univ (Expr.BasilExpr.rvar r) ctx in
+              unify a r)
+            lhs rhs
         in
-        t
+        unify acc e)
+      r p
 
-      let infer visit_constraint ~univ (hr : Lexing.position) e
-          (c : scheme TypeExpr.TCtx.t) =
-        let nexpr =
-          infer_expr visit_constraint ~univ hr e c
-          |> AbsTypingExpr.unfix |> AbstractExpr.get_typ
+  let ctx_to_string ctx =
+    TypeExpr.TCtx.to_iter ctx
+    |> Iter.to_string (fun (a, b) ->
+        Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
+
+  let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
+
+  let do_infer_stmt visit_constraint p univ ctx stmt =
+    let open Stmt in
+    let infer_ty h e = infer_expr visit_constraint ~univ h e ctx in
+    let infer = infer visit_constraint in
+
+    (*let r = fix @@ Var (gen.fresh ()) in*)
+    match stmt with
+    | Instr_IntrinCall _ -> failwith "intrin unsupported"
+    | Instr_Assume { body; branch; attrib } ->
+        let body = infer_ty [%here] body in
+        ignore @@ unify bool_type (getty body);
+        Instr_Assume { body; branch; attrib }
+    | Instr_Assert { body; attrib } ->
+        let body = infer_ty [%here] body in
+        ignore @@ unify bool_type (getty body);
+        Instr_Assert { body; attrib }
+    | Instr_Assign { al = ls; attrib } ->
+        let ls = List.map (fun (l, r) -> (l, infer_ty [%here] r)) ls in
+        List.iter
+          (fun (l, r) ->
+            ignore
+            @@ unify (infer ~univ [%here] (Expr.BasilExpr.rvar l) ctx) (getty r))
+          ls;
+        Instr_Assign { al = ls; attrib }
+    | Instr_Call { lhs; procid; args; attrib } ->
+        let p = Program.proc p procid in
+        let infer_param p =
+          infer
+            ~univ:(TypeExpr.V.proc_univ procid)
+            [%here] (Expr.BasilExpr.rvar p) ctx
         in
-        nexpr
-
-      let unfix i = match i with Expr.BasilExpr.E i -> i
-      let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
-
-      let infer_phi visit_constraint univ ctx (p : Var.t Block.phi list) =
-        let infer = infer visit_constraint in
-        let open Block in
-        let r = fix @@ Var (gen.fresh ()) in
-        List.fold_left
-          (fun acc { lhs; rhs } ->
-            let lhs = infer [%here] ~univ (Expr.BasilExpr.rvar lhs) ctx in
-            let e =
-              List.fold_left
-                (fun a (_, r) ->
-                  let r = infer [%here] ~univ (Expr.BasilExpr.rvar r) ctx in
-                  unify a r)
-                lhs rhs
+        let args = StringMap.mapi (fun param a -> infer_ty [%here] a) args in
+        StringMap.iter
+          (fun parm act ->
+            let form =
+              infer_param (StringMap.find parm (Procedure.formal_in_params p))
             in
-            unify acc e)
-          r p
-
-      let ctx_to_string ctx =
-        TypeExpr.TCtx.to_iter ctx
-        |> Iter.to_string (fun (a, b) ->
-            Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
-
-      let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
-
-      let do_infer_stmt visit_constraint p univ ctx stmt =
-        let open Stmt in
-        let infer_ty h e = infer_expr visit_constraint ~univ h e ctx in
-        let infer = infer visit_constraint in
-
-        (*let r = fix @@ Var (gen.fresh ()) in*)
-        match stmt with
-        | Instr_IntrinCall _ -> failwith "intrin unsupported"
-        | Instr_Assume { body; branch; attrib } ->
-            let body = infer_ty [%here] body in
-            ignore @@ unify bool_type (getty body);
-            Instr_Assume { body; branch; attrib }
-        | Instr_Assert { body; attrib } ->
-            let body = infer_ty [%here] body in
-            ignore @@ unify bool_type (getty body);
-            Instr_Assert { body; attrib }
-        | Instr_Assign { al = ls; attrib } ->
-            let ls = List.map (fun (l, r) -> (l, infer_ty [%here] r)) ls in
-            List.iter
-              (fun (l, r) ->
-                ignore
-                @@ unify
-                     (infer ~univ [%here] (Expr.BasilExpr.rvar l) ctx)
-                     (getty r))
-              ls;
-            Instr_Assign { al = ls; attrib }
-        | Instr_Call { lhs; procid; args; attrib } ->
-            let p = Program.proc p procid in
-            let infer_param p =
-              infer
-                ~univ:(TypeExpr.V.proc_univ procid)
-                [%here] (Expr.BasilExpr.rvar p) ctx
+            ignore @@ unify form (getty act))
+          args;
+        lhs
+        |> StringMap.map (fun a -> infer_ty [%here] (Expr.BasilExpr.rvar a))
+        |> StringMap.iter (fun param act ->
+            let form =
+              infer_param (StringMap.find param @@ Procedure.formal_out_params p)
             in
-            let args =
-              StringMap.mapi (fun param a -> infer_ty [%here] a) args
-            in
-            StringMap.iter
-              (fun parm act ->
-                let form =
-                  infer_param
-                    (StringMap.find parm (Procedure.formal_in_params p))
-                in
-                ignore @@ unify form (getty act))
-              args;
-            lhs
-            |> StringMap.map (fun a -> infer_ty [%here] (Expr.BasilExpr.rvar a))
-            |> StringMap.iter (fun param act ->
-                let form =
-                  infer_param
-                    (StringMap.find param @@ Procedure.formal_out_params p)
-                in
-                ignore @@ unify form (getty act));
-            Instr_Call { lhs; procid; args; attrib }
-        | Instr_IndirectCall { target; attrib } ->
-            let target = infer_ty [%here] target in
-            ignore @@ unify (getty target) ptr_typ;
-            Instr_IndirectCall { target; attrib }
-        | Instr_Load { lhs; rhs; addr = Scalar; attrib } ->
-            let lhs' = infer_ty [%here] (Expr.BasilExpr.rvar lhs) in
-            let rhs' = infer_ty [%here] (Expr.BasilExpr.rvar rhs) in
-            let _ = unify (getty lhs') (getty rhs') in
-            Instr_Load { lhs; rhs; addr = Scalar; attrib }
-        | Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib } ->
-            let addr = infer_ty [%here] addr in
-            let _ = unify ptr_typ (getty addr) in
-            let mapt = fun_type (getty addr) (fresh_tvar ()) in
-            let _ = unify (lookup_var_typ univ ctx rhs) mapt in
-            let _ =
-              unify
-                (infer_ty [%here] (Expr.BasilExpr.rvar lhs) |> getty)
-                (bv_type size)
-            in
-            Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib }
-        | Instr_Store { lhs; rhs; value; addr = Scalar; attrib } ->
-            let value = infer_ty [%here] value in
-            let _ =
-              unify (getty value)
-              @@ unify
-                   (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
-                   (infer ~univ [%here] (Expr.BasilExpr.rvar rhs) ctx)
-            in
-            Instr_Store { lhs; rhs; value; addr = Scalar; attrib }
-        | Instr_Store
-            { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib } ->
-            let addr = infer_ty [%here] addr in
-            let _ = unify ptr_typ (getty addr) in
-            let mapt = fun_type (getty addr) (fresh_tvar ()) in
-            let _ =
-              unify mapt (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
-            in
-            let _ = unify (lookup_var_typ univ ctx rhs) mapt in
-            let value = infer_ty [%here] value in
-            let _ = unify (getty value) (bv_type size) in
-            Instr_Store
-              { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
-
-      let infer_stmt vc p univ ctx s =
-        try do_infer_stmt vc p univ ctx s
-        with TypeErr m ->
-          raise
-            (TypeErr
-               (m ^ " "
-               ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
-
-      let infer_block vc p univ ctx (b : Program.bloc) =
-        let _ = infer_phi vc univ ctx b.phis in
-        Block.map ~phi:Fun.id (infer_stmt vc p univ ctx) b
-
-      let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
-        let globs = Var.Decls.values (Procedure.local_decls p) in
-        let formals_in = Procedure.formal_in_params p |> StringMap.values in
-        let formals_out = Procedure.formal_out_params p |> StringMap.values in
-        let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
-        let ctx =
-          Iter.fold
-            (decl_var_typ ~no_constraint univ)
-            ctx
-            (Iter.append globs @@ Iter.append formals_in formals_out)
+            ignore @@ unify form (getty act));
+        Instr_Call { lhs; procid; args; attrib }
+    | Instr_IndirectCall { target; attrib } ->
+        let target = infer_ty [%here] target in
+        ignore @@ unify (getty target) ptr_typ;
+        Instr_IndirectCall { target; attrib }
+    | Instr_Load { lhs; rhs; addr = Scalar; attrib } ->
+        let lhs' = infer_ty [%here] (Expr.BasilExpr.rvar lhs) in
+        let rhs' = infer_ty [%here] (Expr.BasilExpr.rvar rhs) in
+        let _ = unify (getty lhs') (getty rhs') in
+        Instr_Load { lhs; rhs; addr = Scalar; attrib }
+    | Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib } ->
+        let addr = infer_ty [%here] addr in
+        let _ = unify ptr_typ (getty addr) in
+        let mapt = fun_type (getty addr) (fresh_tvar ()) in
+        let _ = unify (lookup_var_typ univ ctx rhs) mapt in
+        let _ =
+          unify
+            (infer_ty [%here] (Expr.BasilExpr.rvar lhs) |> getty)
+            (bv_type size)
         in
+        Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib }
+    | Instr_Store { lhs; rhs; value; addr = Scalar; attrib } ->
+        let value = infer_ty [%here] value in
+        let _ =
+          unify (getty value)
+          @@ unify
+               (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
+               (infer ~univ [%here] (Expr.BasilExpr.rvar rhs) ctx)
+        in
+        Instr_Store { lhs; rhs; value; addr = Scalar; attrib }
+    | Instr_Store
+        { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib } ->
+        let addr = infer_ty [%here] addr in
+        let _ = unify ptr_typ (getty addr) in
+        let mapt = fun_type (getty addr) (fresh_tvar ()) in
+        let _ =
+          unify mapt (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
+        in
+        let _ = unify (lookup_var_typ univ ctx rhs) mapt in
+        let value = infer_ty [%here] value in
+        let _ = unify (getty value) (bv_type size) in
+        Instr_Store
+          { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
+
+  let infer_stmt vc p univ ctx s =
+    try do_infer_stmt vc p univ ctx s
+    with TypeErr m ->
+      raise
+        (TypeErr
+           (m ^ " "
+           ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
+
+  let infer_block vc p univ ctx (b : Program.bloc) =
+    let _ = infer_phi vc univ ctx b.phis in
+    Block.map ~phi:Fun.id (infer_stmt vc p univ ctx) b
+
+  let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
+    let globs = Var.Decls.values (Procedure.local_decls p) in
+    let formals_in = Procedure.formal_in_params p |> StringMap.values in
+    let formals_out = Procedure.formal_out_params p |> StringMap.values in
+    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
+    let ctx =
+      Iter.fold
+        (decl_var_typ ~no_constraint univ)
         ctx
-    end
+        (Iter.append globs @@ Iter.append formals_in formals_out)
+    in
+    ctx
+end

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -4,340 +4,358 @@ open Hm_types
 
 (** Hindley-Milner type inference based on a union-find. *)
 
-module Make (T : TypeExpr.TypeContext) = struct
-  open Solve_bv.Make (T)
-  open Hm_types.Make (T)
-  open Unification.Make (T)
-  open T
-  open T.Typ
+module Make
+    (T : TypeExpr.TypeContext)
+    (Hm_types' :
+      module type of Hm_types.Make (T))
+        (Unification' :
+          module type of Unification.Make (T))
+            (Hm_types' : module type of Hm_types.Make (T)) =
+        struct
+      open Hm_types.Make (T)
+      open Unification.Make (T) (Hm_types.Make (T))
+      open Solve_bv.Make (T)
+      open T
+      open T.Typ
 
-  (** An AbstractExpr.t with [t] used as the type. *)
-  module AbsTypingExpr = struct
-    open Ops
-    include AllOps
-    module Var = Var
+      (** An AbstractExpr.t with [t] used as the type. *)
+      module AbsTypingExpr = struct
+        open Ops
+        include AllOps
+        module Var = Var
 
-    type var = Var.t
+        type var = Var.t
 
-    type t = E of (const, Var.t, unary, binary, intrin, typ, t) AbstractExpr.t
-    [@@unboxed] [@@deriving eq, ord]
+        type t =
+          | E of (const, Var.t, unary, binary, intrin, typ, t) AbstractExpr.t
+        [@@unboxed] [@@deriving eq, ord]
 
-    type nonrec typ = typ
+        type nonrec typ = typ
 
-    let top_typ = top_t
-    let fix i = E i
-    let unfix i = match i with E i -> i
-  end
-
-  module TypingExpr = Expr.Make (AbsTypingExpr)
-
-  let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
-
-  let infer_var univ ctx id =
-    let typ = lookup_var_typ univ ctx id in
-    (id, typ)
-
-  (** Return the generic type scheme for an op. We generalise the type, and hope
-      dearly that a concrete type is found by inference.
-
-      TODO: some approach like weak type variables that makes it a type error to
-      fail to instantiate. *)
-  let scheme_of_op ~visit_constraint (gen : ID.generator)
-      (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
-    let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
-    match o with
-    | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
-    | `SignExtend bits ->
-        let a = fv () in
-        let equ = fv () in
-        let r = curry_f [ bvunk a ] (bvunk equ) in
-        visit_constraint @@ AddConst { a; b = bits; equ };
-        r
-    | `ZeroExtend bits ->
-        let a = fv () and equ = fv () in
-        visit_constraint @@ AddConst { a; b = bits; equ };
-        curry_f [ bvunk a ] (bvunk equ)
-    | `BOOLTOBV1 -> curry_f [ bool_type ] (bv_type 1)
-    | `Bitvector b -> bv_type (Bitvec.size b)
-    | #Ops.BVOps.binary_unif ->
-        let a = fv () in
-        curry_f [ bvunk a; bvunk a ] (bvunk a)
-    | #Ops.BVOps.binary_pred ->
-        let a = fv () in
-        curry_f [ bvunk a; bvunk a ] bool_type
-    | #Ops.BVOps.unary_unif ->
-        let a = fv () in
-        curry_f [ bvunk a ] (bvunk a)
-    | `INTNEG -> curry_f [ int_type ] int_type
-    | #Ops.IntOps.binary_pred -> curry_f [ int_type; int_type ] bool_type
-    | #Ops.IntOps.const -> int_type
-    | #Ops.IntOps.binary_unif -> curry_f [ int_type; int_type ] int_type
-    | #Ops.LogicalOps.binary -> curry_f [ bool_type; bool_type ] bool_type
-    | #Ops.LogicalOps.unary -> curry_f [ bool_type ] bool_type
-    | #Ops.LogicalOps.const -> bool_type
-    | `Old ->
-        let a = fv () in
-        curry_f [ a ] a
-    | #Ops.AllOps.binary as o ->
-        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-    | #Ops.AllOps.unary as o ->
-        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-    | #Ops.AllOps.const as o ->
-        failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
-
-  (** return the generic type scheme of an intrinsic operation *)
-  let scheme_of_intrin ?(visit_constraint = fun a -> ()) (gen : ID.generator)
-      (o : Ops.AllOps.intrin) args =
-    let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
-    match o with
-    | `BVADD | `BVMUL | `BVOR | `BVXOR | `BVAND ->
-        let a = fv () in
-        curry_f (List.init args (fun _ -> a)) a
-    | `BVConcat ->
-        let args = List.init args (fun _ -> fv ()) in
-        let rs =
-          List.reduce_exn
-            (fun a b ->
-              let equ = fv () in
-              visit_constraint (Add { a; b; equ });
-              equ)
-            args
-        in
-        let rs = bvunk rs in
-        let args = List.map bvunk args in
-        curry_f args rs
-    | `OR | `AND -> curry_f (List.init args (fun _ -> bool_type)) bool_type
-    | `MapUpdate ->
-        let a = fv () in
-        let b = fv () in
-        let m = curry_f [ a ] b in
-        curry_f [ m; a; b ] m
-    | `Cases -> fv ()
-
-  let do_infer ~visit_constraint
-      (infer :
-        univ:string ->
-        Lexing.position ->
-        Program.e ->
-        scheme TypeExpr.TCtx.t ->
-        AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
-    let mkv v = TypeExpr.V.of_var univ v in
-    let r = fix @@ Var (gen.fresh ()) in
-    let open Abstract_expr.AbstractExpr in
-    let e = Expr.BasilExpr.unfix e in
-    let e = set_typ e r in
-    match e with
-    | RVar { id; attrib } ->
-        let typ = lookup_var_typ univ c id in
-        AbsTypingExpr.fix (RVar { attrib; id; typ })
-    | Lambda { op; bound_vars; in_body; attrib; triggers } -> begin
-        let tvars = List.map (fun v -> (v, inst_annot_v v)) bound_vars in
-        let ictx =
-          List.map (fun (v, t) -> (mkv v, Forall ([], t))) tvars
-          |> TypeExpr.TCtx.add_list c
-        in
-        let bdty = infer ~univ [%here] in_body ictx in
-        let typ =
-          match op with
-          | `Lambda -> getty bdty
-          | `Forall | `Exists -> unify (getty bdty) bool_type
-        in
-        ignore @@ unify r (curry_f (List.map snd tvars) (getty bdty));
-        let triggers =
-          List.map (List.map (fun e -> infer ~univ [%here] e ictx)) triggers
-        in
-        AbsTypingExpr.fix
-          (Lambda { op; bound_vars; in_body = bdty; attrib; typ; triggers })
+        let top_typ = top_t
+        let fix i = E i
+        let unfix i = match i with E i -> i
       end
-    | Constant { const = #Ops.AllOps.const as op; attrib } -> begin
-        let f = scheme_of_op ~visit_constraint gen op in
-        let r = unify r f in
-        AbsTypingExpr.fix (Constant { typ = r; const = op; attrib })
-      end
-    | UnaryExpr { op = #Ops.AllOps.unary as op; arg; attrib } -> begin
-        let f = scheme_of_op ~visit_constraint gen op in
-        let arg = infer ~univ [%here] arg c in
-        ignore @@ unify f (curry_f [ getty arg ] r);
-        AbsTypingExpr.fix (UnaryExpr { typ = r; op; attrib; arg })
-      end
-    | BinaryExpr { op = #Ops.AllOps.binary as op; arg1; arg2; attrib } -> begin
-        let f = scheme_of_op ~visit_constraint gen op in
-        let arg1 = infer ~univ [%here] arg1 c in
-        let arg2 = infer ~univ [%here] arg2 c in
-        ignore @@ unify f (curry_f [ getty arg1; getty arg2 ] r);
-        AbsTypingExpr.fix (BinaryExpr { typ = r; op; attrib; arg1; arg2 })
-      end
-    | ApplyIntrin { op = #Ops.AllOps.intrin as op; args; attrib } -> begin
-        let f = scheme_of_intrin ~visit_constraint gen op (List.length args) in
-        let args = List.map (fun a -> infer ~univ [%here] a c) args in
-        ignore @@ unify f (curry_f (List.map getty args) r);
-        AbsTypingExpr.fix (ApplyIntrin { typ = r; op; attrib; args })
-      end
-    | ApplyFun { func; args; attrib } ->
-        let f = infer ~univ [%here] func c in
-        let args = List.map (fun a -> infer ~univ [%here] a c) args in
-        ignore @@ unify (getty f) (curry_f (List.map getty args) r);
-        AbsTypingExpr.fix (ApplyFun { typ = r; func = f; attrib; args })
-    | Let _ -> failwith ""
 
-  let rec infer_expr visit_constraint ~univ (hr : Lexing.position) e =
-   fun (c : scheme TypeExpr.TCtx.t) ->
-    Logs.debug (fun m ->
-        m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
-    let t =
-      try do_infer ~visit_constraint (infer_expr visit_constraint) univ hr e c
-      with TypeErr m ->
-        raise (TypeErr (m ^ " : " ^ Expr.BasilExpr.to_string e))
-    in
-    t
+      module TypingExpr = Expr.Make (AbsTypingExpr)
 
-  let infer visit_constraint ~univ (hr : Lexing.position) e
-      (c : scheme TypeExpr.TCtx.t) =
-    let nexpr =
-      infer_expr visit_constraint ~univ hr e c
-      |> AbsTypingExpr.unfix |> AbstractExpr.get_typ
-    in
-    nexpr
+      let getty = AbsTypingExpr.unfix %> Expr.AbstractExpr.get_typ
 
-  let unfix i = match i with Expr.BasilExpr.E i -> i
-  let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
+      let infer_var univ ctx id =
+        let typ = lookup_var_typ univ ctx id in
+        (id, typ)
 
-  let infer_phi visit_constraint univ ctx (p : Var.t Block.phi list) =
-    let infer = infer visit_constraint in
-    let open Block in
-    let r = fix @@ Var (gen.fresh ()) in
-    List.fold_left
-      (fun acc { lhs; rhs } ->
-        let lhs = infer [%here] ~univ (Expr.BasilExpr.rvar lhs) ctx in
-        let e =
-          List.fold_left
-            (fun a (_, r) ->
-              let r = infer [%here] ~univ (Expr.BasilExpr.rvar r) ctx in
-              unify a r)
-            lhs rhs
-        in
-        unify acc e)
-      r p
+      (** Return the generic type scheme for an op. We generalise the type, and
+          hope dearly that a concrete type is found by inference.
 
-  let ctx_to_string ctx =
-    TypeExpr.TCtx.to_iter ctx
-    |> Iter.to_string (fun (a, b) ->
-        Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
+          TODO: some approach like weak type variables that makes it a type
+          error to fail to instantiate. *)
+      let scheme_of_op ~visit_constraint (gen : ID.generator)
+          (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
+        let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
+        match o with
+        | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
+        | `SignExtend bits ->
+            let a = fv () in
+            let equ = fv () in
+            let r = curry_f [ bvunk a ] (bvunk equ) in
+            visit_constraint @@ AddConst { a; b = bits; equ };
+            r
+        | `ZeroExtend bits ->
+            let a = fv () and equ = fv () in
+            visit_constraint @@ AddConst { a; b = bits; equ };
+            curry_f [ bvunk a ] (bvunk equ)
+        | `BOOLTOBV1 -> curry_f [ bool_type ] (bv_type 1)
+        | `Bitvector b -> bv_type (Bitvec.size b)
+        | #Ops.BVOps.binary_unif ->
+            let a = fv () in
+            curry_f [ bvunk a; bvunk a ] (bvunk a)
+        | #Ops.BVOps.binary_pred ->
+            let a = fv () in
+            curry_f [ bvunk a; bvunk a ] bool_type
+        | #Ops.BVOps.unary_unif ->
+            let a = fv () in
+            curry_f [ bvunk a ] (bvunk a)
+        | `INTNEG -> curry_f [ int_type ] int_type
+        | #Ops.IntOps.binary_pred -> curry_f [ int_type; int_type ] bool_type
+        | #Ops.IntOps.const -> int_type
+        | #Ops.IntOps.binary_unif -> curry_f [ int_type; int_type ] int_type
+        | #Ops.LogicalOps.binary -> curry_f [ bool_type; bool_type ] bool_type
+        | #Ops.LogicalOps.unary -> curry_f [ bool_type ] bool_type
+        | #Ops.LogicalOps.const -> bool_type
+        | `Old ->
+            let a = fv () in
+            curry_f [ a ] a
+        | #Ops.AllOps.binary as o ->
+            failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+        | #Ops.AllOps.unary as o ->
+            failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
+        | #Ops.AllOps.const as o ->
+            failwith @@ "unsupported op" ^ Ops.AllOps.to_string o
 
-  let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
-
-  let do_infer_stmt visit_constraint p univ ctx stmt =
-    let open Stmt in
-    let infer_ty h e = infer_expr visit_constraint ~univ h e ctx in
-    let infer = infer visit_constraint in
-
-    (*let r = fix @@ Var (gen.fresh ()) in*)
-    match stmt with
-    | Instr_IntrinCall _ -> failwith "intrin unsupported"
-    | Instr_Assume { body; branch; attrib } ->
-        let body = infer_ty [%here] body in
-        ignore @@ unify bool_type (getty body);
-        Instr_Assume { body; branch; attrib }
-    | Instr_Assert { body; attrib } ->
-        let body = infer_ty [%here] body in
-        ignore @@ unify bool_type (getty body);
-        Instr_Assert { body; attrib }
-    | Instr_Assign { al = ls; attrib } ->
-        let ls = List.map (fun (l, r) -> (l, infer_ty [%here] r)) ls in
-        List.iter
-          (fun (l, r) ->
-            ignore
-            @@ unify (infer ~univ [%here] (Expr.BasilExpr.rvar l) ctx) (getty r))
-          ls;
-        Instr_Assign { al = ls; attrib }
-    | Instr_Call { lhs; procid; args; attrib } ->
-        let p = Program.proc p procid in
-        let infer_param p =
-          infer
-            ~univ:(TypeExpr.V.proc_univ procid)
-            [%here] (Expr.BasilExpr.rvar p) ctx
-        in
-        let args = StringMap.mapi (fun param a -> infer_ty [%here] a) args in
-        StringMap.iter
-          (fun parm act ->
-            let form =
-              infer_param (StringMap.find parm (Procedure.formal_in_params p))
+      (** return the generic type scheme of an intrinsic operation *)
+      let scheme_of_intrin ?(visit_constraint = fun a -> ())
+          (gen : ID.generator) (o : Ops.AllOps.intrin) args =
+        let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
+        match o with
+        | `BVADD | `BVMUL | `BVOR | `BVXOR | `BVAND ->
+            let a = fv () in
+            curry_f (List.init args (fun _ -> a)) a
+        | `BVConcat ->
+            let args = List.init args (fun _ -> fv ()) in
+            let rs =
+              List.reduce_exn
+                (fun a b ->
+                  let equ = fv () in
+                  visit_constraint (Add { a; b; equ });
+                  equ)
+                args
             in
-            ignore @@ unify form (getty act))
-          args;
-        lhs
-        |> StringMap.map (fun a -> infer_ty [%here] (Expr.BasilExpr.rvar a))
-        |> StringMap.iter (fun param act ->
-            let form =
-              infer_param (StringMap.find param @@ Procedure.formal_out_params p)
+            let rs = bvunk rs in
+            let args = List.map bvunk args in
+            curry_f args rs
+        | `OR | `AND -> curry_f (List.init args (fun _ -> bool_type)) bool_type
+        | `MapUpdate ->
+            let a = fv () in
+            let b = fv () in
+            let m = curry_f [ a ] b in
+            curry_f [ m; a; b ] m
+        | `Cases -> fv ()
+
+      let do_infer ~visit_constraint
+          (infer :
+            univ:string ->
+            Lexing.position ->
+            Program.e ->
+            scheme TypeExpr.TCtx.t ->
+            AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
+        let mkv v = TypeExpr.V.of_var univ v in
+        let r = fix @@ Var (gen.fresh ()) in
+        let open Abstract_expr.AbstractExpr in
+        let e = Expr.BasilExpr.unfix e in
+        let e = set_typ e r in
+        match e with
+        | RVar { id; attrib } ->
+            let typ = lookup_var_typ univ c id in
+            AbsTypingExpr.fix (RVar { attrib; id; typ })
+        | Lambda { op; bound_vars; in_body; attrib; triggers } -> begin
+            let tvars = List.map (fun v -> (v, inst_annot_v v)) bound_vars in
+            let ictx =
+              List.map (fun (v, t) -> (mkv v, Forall ([], t))) tvars
+              |> TypeExpr.TCtx.add_list c
             in
-            ignore @@ unify form (getty act));
-        Instr_Call { lhs; procid; args; attrib }
-    | Instr_IndirectCall { target; attrib } ->
-        let target = infer_ty [%here] target in
-        ignore @@ unify (getty target) ptr_typ;
-        Instr_IndirectCall { target; attrib }
-    | Instr_Load { lhs; rhs; addr = Scalar; attrib } ->
-        let lhs' = infer_ty [%here] (Expr.BasilExpr.rvar lhs) in
-        let rhs' = infer_ty [%here] (Expr.BasilExpr.rvar rhs) in
-        let _ = unify (getty lhs') (getty rhs') in
-        Instr_Load { lhs; rhs; addr = Scalar; attrib }
-    | Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib } ->
-        let addr = infer_ty [%here] addr in
-        let _ = unify ptr_typ (getty addr) in
-        let mapt = fun_type (getty addr) (fresh_tvar ()) in
-        let _ = unify (lookup_var_typ univ ctx rhs) mapt in
-        let _ =
-          unify
-            (infer_ty [%here] (Expr.BasilExpr.rvar lhs) |> getty)
-            (bv_type size)
-        in
-        Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib }
-    | Instr_Store { lhs; rhs; value; addr = Scalar; attrib } ->
-        let value = infer_ty [%here] value in
-        let _ =
-          unify (getty value)
-          @@ unify
-               (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
-               (infer ~univ [%here] (Expr.BasilExpr.rvar rhs) ctx)
-        in
-        Instr_Store { lhs; rhs; value; addr = Scalar; attrib }
-    | Instr_Store
-        { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib } ->
-        let addr = infer_ty [%here] addr in
-        let _ = unify ptr_typ (getty addr) in
-        let mapt = fun_type (getty addr) (fresh_tvar ()) in
-        let _ =
-          unify mapt (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
-        in
-        let _ = unify (lookup_var_typ univ ctx rhs) mapt in
-        let value = infer_ty [%here] value in
-        let _ = unify (getty value) (bv_type size) in
-        Instr_Store
-          { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
+            let bdty = infer ~univ [%here] in_body ictx in
+            let typ =
+              match op with
+              | `Lambda -> getty bdty
+              | `Forall | `Exists -> unify (getty bdty) bool_type
+            in
+            ignore @@ unify r (curry_f (List.map snd tvars) (getty bdty));
+            let triggers =
+              List.map (List.map (fun e -> infer ~univ [%here] e ictx)) triggers
+            in
+            AbsTypingExpr.fix
+              (Lambda { op; bound_vars; in_body = bdty; attrib; typ; triggers })
+          end
+        | Constant { const = #Ops.AllOps.const as op; attrib } -> begin
+            let f = scheme_of_op ~visit_constraint gen op in
+            let r = unify r f in
+            AbsTypingExpr.fix (Constant { typ = r; const = op; attrib })
+          end
+        | UnaryExpr { op = #Ops.AllOps.unary as op; arg; attrib } -> begin
+            let f = scheme_of_op ~visit_constraint gen op in
+            let arg = infer ~univ [%here] arg c in
+            ignore @@ unify f (curry_f [ getty arg ] r);
+            AbsTypingExpr.fix (UnaryExpr { typ = r; op; attrib; arg })
+          end
+        | BinaryExpr { op = #Ops.AllOps.binary as op; arg1; arg2; attrib } ->
+          begin
+            let f = scheme_of_op ~visit_constraint gen op in
+            let arg1 = infer ~univ [%here] arg1 c in
+            let arg2 = infer ~univ [%here] arg2 c in
+            ignore @@ unify f (curry_f [ getty arg1; getty arg2 ] r);
+            AbsTypingExpr.fix (BinaryExpr { typ = r; op; attrib; arg1; arg2 })
+          end
+        | ApplyIntrin { op = #Ops.AllOps.intrin as op; args; attrib } -> begin
+            let f =
+              scheme_of_intrin ~visit_constraint gen op (List.length args)
+            in
+            let args = List.map (fun a -> infer ~univ [%here] a c) args in
+            ignore @@ unify f (curry_f (List.map getty args) r);
+            AbsTypingExpr.fix (ApplyIntrin { typ = r; op; attrib; args })
+          end
+        | ApplyFun { func; args; attrib } ->
+            let f = infer ~univ [%here] func c in
+            let args = List.map (fun a -> infer ~univ [%here] a c) args in
+            ignore @@ unify (getty f) (curry_f (List.map getty args) r);
+            AbsTypingExpr.fix (ApplyFun { typ = r; func = f; attrib; args })
+        | Let _ -> failwith ""
 
-  let infer_stmt vc p univ ctx s =
-    try do_infer_stmt vc p univ ctx s
-    with TypeErr m ->
-      raise
-        (TypeErr
-           (m ^ " "
-           ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
+      let rec infer_expr visit_constraint ~univ (hr : Lexing.position) e =
+       fun (c : scheme TypeExpr.TCtx.t) ->
+        Logs.debug (fun m ->
+            m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
+        let t =
+          try
+            do_infer ~visit_constraint (infer_expr visit_constraint) univ hr e c
+          with TypeErr m ->
+            raise (TypeErr (m ^ " : " ^ Expr.BasilExpr.to_string e))
+        in
+        t
 
-  let infer_block vc p univ ctx (b : Program.bloc) =
-    let _ = infer_phi vc univ ctx b.phis in
-    Block.map ~phi:Fun.id (infer_stmt vc p univ ctx) b
+      let infer visit_constraint ~univ (hr : Lexing.position) e
+          (c : scheme TypeExpr.TCtx.t) =
+        let nexpr =
+          infer_expr visit_constraint ~univ hr e c
+          |> AbsTypingExpr.unfix |> AbstractExpr.get_typ
+        in
+        nexpr
 
-  let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
-    let globs = Var.Decls.values (Procedure.local_decls p) in
-    let formals_in = Procedure.formal_in_params p |> StringMap.values in
-    let formals_out = Procedure.formal_out_params p |> StringMap.values in
-    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
-    let ctx =
-      Iter.fold
-        (decl_var_typ ~no_constraint univ)
+      let unfix i = match i with Expr.BasilExpr.E i -> i
+      let rec cata alg e = (unfix %> AbstractExpr.map (cata alg) %> alg) e
+
+      let infer_phi visit_constraint univ ctx (p : Var.t Block.phi list) =
+        let infer = infer visit_constraint in
+        let open Block in
+        let r = fix @@ Var (gen.fresh ()) in
+        List.fold_left
+          (fun acc { lhs; rhs } ->
+            let lhs = infer [%here] ~univ (Expr.BasilExpr.rvar lhs) ctx in
+            let e =
+              List.fold_left
+                (fun a (_, r) ->
+                  let r = infer [%here] ~univ (Expr.BasilExpr.rvar r) ctx in
+                  unify a r)
+                lhs rhs
+            in
+            unify acc e)
+          r p
+
+      let ctx_to_string ctx =
+        TypeExpr.TCtx.to_iter ctx
+        |> Iter.to_string (fun (a, b) ->
+            Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
+
+      let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
+
+      let do_infer_stmt visit_constraint p univ ctx stmt =
+        let open Stmt in
+        let infer_ty h e = infer_expr visit_constraint ~univ h e ctx in
+        let infer = infer visit_constraint in
+
+        (*let r = fix @@ Var (gen.fresh ()) in*)
+        match stmt with
+        | Instr_IntrinCall _ -> failwith "intrin unsupported"
+        | Instr_Assume { body; branch; attrib } ->
+            let body = infer_ty [%here] body in
+            ignore @@ unify bool_type (getty body);
+            Instr_Assume { body; branch; attrib }
+        | Instr_Assert { body; attrib } ->
+            let body = infer_ty [%here] body in
+            ignore @@ unify bool_type (getty body);
+            Instr_Assert { body; attrib }
+        | Instr_Assign { al = ls; attrib } ->
+            let ls = List.map (fun (l, r) -> (l, infer_ty [%here] r)) ls in
+            List.iter
+              (fun (l, r) ->
+                ignore
+                @@ unify
+                     (infer ~univ [%here] (Expr.BasilExpr.rvar l) ctx)
+                     (getty r))
+              ls;
+            Instr_Assign { al = ls; attrib }
+        | Instr_Call { lhs; procid; args; attrib } ->
+            let p = Program.proc p procid in
+            let infer_param p =
+              infer
+                ~univ:(TypeExpr.V.proc_univ procid)
+                [%here] (Expr.BasilExpr.rvar p) ctx
+            in
+            let args =
+              StringMap.mapi (fun param a -> infer_ty [%here] a) args
+            in
+            StringMap.iter
+              (fun parm act ->
+                let form =
+                  infer_param
+                    (StringMap.find parm (Procedure.formal_in_params p))
+                in
+                ignore @@ unify form (getty act))
+              args;
+            lhs
+            |> StringMap.map (fun a -> infer_ty [%here] (Expr.BasilExpr.rvar a))
+            |> StringMap.iter (fun param act ->
+                let form =
+                  infer_param
+                    (StringMap.find param @@ Procedure.formal_out_params p)
+                in
+                ignore @@ unify form (getty act));
+            Instr_Call { lhs; procid; args; attrib }
+        | Instr_IndirectCall { target; attrib } ->
+            let target = infer_ty [%here] target in
+            ignore @@ unify (getty target) ptr_typ;
+            Instr_IndirectCall { target; attrib }
+        | Instr_Load { lhs; rhs; addr = Scalar; attrib } ->
+            let lhs' = infer_ty [%here] (Expr.BasilExpr.rvar lhs) in
+            let rhs' = infer_ty [%here] (Expr.BasilExpr.rvar rhs) in
+            let _ = unify (getty lhs') (getty rhs') in
+            Instr_Load { lhs; rhs; addr = Scalar; attrib }
+        | Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib } ->
+            let addr = infer_ty [%here] addr in
+            let _ = unify ptr_typ (getty addr) in
+            let mapt = fun_type (getty addr) (fresh_tvar ()) in
+            let _ = unify (lookup_var_typ univ ctx rhs) mapt in
+            let _ =
+              unify
+                (infer_ty [%here] (Expr.BasilExpr.rvar lhs) |> getty)
+                (bv_type size)
+            in
+            Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib }
+        | Instr_Store { lhs; rhs; value; addr = Scalar; attrib } ->
+            let value = infer_ty [%here] value in
+            let _ =
+              unify (getty value)
+              @@ unify
+                   (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
+                   (infer ~univ [%here] (Expr.BasilExpr.rvar rhs) ctx)
+            in
+            Instr_Store { lhs; rhs; value; addr = Scalar; attrib }
+        | Instr_Store
+            { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib } ->
+            let addr = infer_ty [%here] addr in
+            let _ = unify ptr_typ (getty addr) in
+            let mapt = fun_type (getty addr) (fresh_tvar ()) in
+            let _ =
+              unify mapt (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
+            in
+            let _ = unify (lookup_var_typ univ ctx rhs) mapt in
+            let value = infer_ty [%here] value in
+            let _ = unify (getty value) (bv_type size) in
+            Instr_Store
+              { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
+
+      let infer_stmt vc p univ ctx s =
+        try do_infer_stmt vc p univ ctx s
+        with TypeErr m ->
+          raise
+            (TypeErr
+               (m ^ " "
+               ^ Stmt.to_string Var.pretty Var.pretty Expr.BasilExpr.pretty s))
+
+      let infer_block vc p univ ctx (b : Program.bloc) =
+        let _ = infer_phi vc univ ctx b.phis in
+        Block.map ~phi:Fun.id (infer_stmt vc p univ ctx) b
+
+      let assume_proc_decl ctx ?(no_constraint = false) (p : Program.proc) =
+        let globs = Var.Decls.values (Procedure.local_decls p) in
+        let formals_in = Procedure.formal_in_params p |> StringMap.values in
+        let formals_out = Procedure.formal_out_params p |> StringMap.values in
+        let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
+        let ctx =
+          Iter.fold
+            (decl_var_typ ~no_constraint univ)
+            ctx
+            (Iter.append globs @@ Iter.append formals_in formals_out)
+        in
         ctx
-        (Iter.append globs @@ Iter.append formals_in formals_out)
-    in
-    ctx
-end
+    end

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -8,6 +8,8 @@ module Make (T : TypeExpr.TypeContext) = struct
   open Solve_bv.Make (T)
   open Hm_types.Make (T)
   open Unification.Make (T)
+  open T
+  open T.Typ
 
   (** An AbstractExpr.t with [t] used as the type. *)
   module AbsTypingExpr = struct

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -5,8 +5,9 @@ open Hm_types
 (** Hindley-Milner type inference based on a union-find. *)
 
 module Make (T : TypeExpr.TypeContext) = struct
-  open TypeExpr
-  include Solve_bv.Make (T)
+  open Solve_bv.Make (T)
+  open Hm_types.Make (T)
+  open Unification.Make (T)
 
   (** An AbstractExpr.t with [t] used as the type. *)
   module AbsTypingExpr = struct
@@ -21,7 +22,7 @@ module Make (T : TypeExpr.TypeContext) = struct
 
     type nonrec typ = typ
 
-    let top_typ = fix @@ top_t
+    let top_typ = T.Typ.fix @@ top_t
     let fix i = E i
     let unfix i = match i with E i -> i
   end
@@ -116,9 +117,9 @@ module Make (T : TypeExpr.TypeContext) = struct
         univ:string ->
         Lexing.position ->
         Program.e ->
-        scheme TCtx.t ->
+        scheme TypeExpr.TCtx.t ->
         AbsTypingExpr.t) univ hr e c : AbsTypingExpr.t =
-    let mkv v = V.of_var univ v in
+    let mkv v = TypeExpr.V.of_var univ v in
     let r = fix @@ Var (gen.fresh ()) in
     let open Abstract_expr.AbstractExpr in
     let e = Expr.BasilExpr.unfix e in
@@ -131,7 +132,7 @@ module Make (T : TypeExpr.TypeContext) = struct
         let tvars = List.map (fun v -> (v, inst_annot_v v)) bound_vars in
         let ictx =
           List.map (fun (v, t) -> (mkv v, Forall ([], t))) tvars
-          |> TCtx.add_list c
+          |> TypeExpr.TCtx.add_list c
         in
         let bdty = infer ~univ [%here] in_body ictx in
         let typ =
@@ -178,7 +179,7 @@ module Make (T : TypeExpr.TypeContext) = struct
     | Let _ -> failwith ""
 
   let rec infer_expr visit_constraint ~univ (hr : Lexing.position) e =
-   fun (c : scheme TCtx.t) ->
+   fun (c : scheme TypeExpr.TCtx.t) ->
     Logs.debug (fun m ->
         m "%s" @@ "infer " ^ plpos hr ^ " " ^ Expr.BasilExpr.to_string e);
     let t =
@@ -188,8 +189,8 @@ module Make (T : TypeExpr.TypeContext) = struct
     in
     t
 
-  let infer visit_constraint ~univ (hr : Lexing.position) e (c : scheme TCtx.t)
-      =
+  let infer visit_constraint ~univ (hr : Lexing.position) e
+      (c : scheme TypeExpr.TCtx.t) =
     let nexpr =
       infer_expr visit_constraint ~univ hr e c
       |> AbsTypingExpr.unfix |> AbstractExpr.get_typ
@@ -217,9 +218,9 @@ module Make (T : TypeExpr.TypeContext) = struct
       r p
 
   let ctx_to_string ctx =
-    TCtx.to_iter ctx
+    TypeExpr.TCtx.to_iter ctx
     |> Iter.to_string (fun (a, b) ->
-        Printf.sprintf "%s %s" (V.to_string a) (scheme_to_string b))
+        Printf.sprintf "%s %s" (TypeExpr.V.to_string a) (scheme_to_string b))
 
   let fresh_tvar ?(n = "a") () = fix @@ Var (gen.fresh ~name:n ())
 
@@ -250,7 +251,9 @@ module Make (T : TypeExpr.TypeContext) = struct
     | Instr_Call { lhs; procid; args; attrib } ->
         let p = Program.proc p procid in
         let infer_param p =
-          infer ~univ:(V.proc_univ procid) [%here] (Expr.BasilExpr.rvar p) ctx
+          infer
+            ~univ:(TypeExpr.V.proc_univ procid)
+            [%here] (Expr.BasilExpr.rvar p) ctx
         in
         let args = StringMap.mapi (fun param a -> infer_ty [%here] a) args in
         StringMap.iter
@@ -327,7 +330,7 @@ module Make (T : TypeExpr.TypeContext) = struct
     let globs = Var.Decls.values (Procedure.local_decls p) in
     let formals_in = Procedure.formal_in_params p |> StringMap.values in
     let formals_out = Procedure.formal_out_params p |> StringMap.values in
-    let univ = V.proc_univ @@ Procedure.id p in
+    let univ = TypeExpr.V.proc_univ @@ Procedure.id p in
     let ctx =
       Iter.fold
         (decl_var_typ ~no_constraint univ)

--- a/lib/lang/hm/inference.ml
+++ b/lib/lang/hm/inference.ml
@@ -24,7 +24,7 @@ module Make (T : TypeExpr.TypeContext) = struct
 
     type nonrec typ = typ
 
-    let top_typ = T.Typ.fix @@ top_t
+    let top_typ = top_t
     let fix i = E i
     let unfix i = match i with E i -> i
   end
@@ -46,35 +46,35 @@ module Make (T : TypeExpr.TypeContext) = struct
       (o : [ Ops.AllOps.const | Ops.AllOps.unary | Ops.AllOps.binary ]) =
     let fv () = fix @@ Var (gen.fresh ~name:"a" ()) in
     match o with
-    | `Extract (hi, lo) -> curry [ bvunk (fv ()) ] (bv_type (hi - lo))
+    | `Extract (hi, lo) -> curry_f [ bvunk (fv ()) ] (bv_type (hi - lo))
     | `SignExtend bits ->
         let a = fv () in
         let equ = fv () in
-        let r = curry [ bvunk a ] (bvunk equ) in
+        let r = curry_f [ bvunk a ] (bvunk equ) in
         visit_constraint @@ AddConst { a; b = bits; equ };
         r
     | `ZeroExtend bits ->
         let a = fv () and equ = fv () in
         visit_constraint @@ AddConst { a; b = bits; equ };
-        curry [ bvunk a ] (bvunk equ)
-    | `BOOLTOBV1 -> curry [ bool_type ] (bv_type 1)
-    | `Bitvector b -> fix @@ bv_type (Bitvec.size b)
+        curry_f [ bvunk a ] (bvunk equ)
+    | `BOOLTOBV1 -> curry_f [ bool_type ] (bv_type 1)
+    | `Bitvector b -> bv_type (Bitvec.size b)
     | #Ops.BVOps.binary_unif ->
         let a = fv () in
-        curry [ bvunk a; bvunk a ] (bvunk a)
+        curry_f [ bvunk a; bvunk a ] (bvunk a)
     | #Ops.BVOps.binary_pred ->
         let a = fv () in
-        curry [ bvunk a; bvunk a ] bool_type
+        curry_f [ bvunk a; bvunk a ] bool_type
     | #Ops.BVOps.unary_unif ->
         let a = fv () in
-        curry [ bvunk a ] (bvunk a)
-    | `INTNEG -> curry [ int_type ] int_type
-    | #Ops.IntOps.binary_pred -> curry [ int_type; int_type ] bool_type
-    | #Ops.IntOps.const -> fix @@ int_type
-    | #Ops.IntOps.binary_unif -> curry [ int_type; int_type ] int_type
-    | #Ops.LogicalOps.binary -> curry [ bool_type; bool_type ] bool_type
-    | #Ops.LogicalOps.unary -> curry [ bool_type ] bool_type
-    | #Ops.LogicalOps.const -> fix @@ bool_type
+        curry_f [ bvunk a ] (bvunk a)
+    | `INTNEG -> curry_f [ int_type ] int_type
+    | #Ops.IntOps.binary_pred -> curry_f [ int_type; int_type ] bool_type
+    | #Ops.IntOps.const -> int_type
+    | #Ops.IntOps.binary_unif -> curry_f [ int_type; int_type ] int_type
+    | #Ops.LogicalOps.binary -> curry_f [ bool_type; bool_type ] bool_type
+    | #Ops.LogicalOps.unary -> curry_f [ bool_type ] bool_type
+    | #Ops.LogicalOps.const -> bool_type
     | `Old ->
         let a = fv () in
         curry_f [ a ] a
@@ -105,8 +105,8 @@ module Make (T : TypeExpr.TypeContext) = struct
         in
         let rs = bvunk rs in
         let args = List.map bvunk args in
-        curry args rs
-    | `OR | `AND -> curry (List.init args (fun _ -> bool_type)) bool_type
+        curry_f args rs
+    | `OR | `AND -> curry_f (List.init args (fun _ -> bool_type)) bool_type
     | `MapUpdate ->
         let a = fv () in
         let b = fv () in
@@ -140,7 +140,7 @@ module Make (T : TypeExpr.TypeContext) = struct
         let typ =
           match op with
           | `Lambda -> getty bdty
-          | `Forall | `Exists -> unify (getty bdty) (fix bool_type)
+          | `Forall | `Exists -> unify (getty bdty) bool_type
         in
         ignore @@ unify r (curry_f (List.map snd tvars) (getty bdty));
         let triggers =
@@ -236,11 +236,11 @@ module Make (T : TypeExpr.TypeContext) = struct
     | Instr_IntrinCall _ -> failwith "intrin unsupported"
     | Instr_Assume { body; branch; attrib } ->
         let body = infer_ty [%here] body in
-        ignore @@ unify (fix bool_type) (getty body);
+        ignore @@ unify bool_type (getty body);
         Instr_Assume { body; branch; attrib }
     | Instr_Assert { body; attrib } ->
         let body = infer_ty [%here] body in
-        ignore @@ unify (fix bool_type) (getty body);
+        ignore @@ unify bool_type (getty body);
         Instr_Assert { body; attrib }
     | Instr_Assign { al = ls; attrib } ->
         let ls = List.map (fun (l, r) -> (l, infer_ty [%here] r)) ls in
@@ -275,7 +275,7 @@ module Make (T : TypeExpr.TypeContext) = struct
         Instr_Call { lhs; procid; args; attrib }
     | Instr_IndirectCall { target; attrib } ->
         let target = infer_ty [%here] target in
-        ignore @@ unify (getty target) (fix ptr_typ);
+        ignore @@ unify (getty target) ptr_typ;
         Instr_IndirectCall { target; attrib }
     | Instr_Load { lhs; rhs; addr = Scalar; attrib } ->
         let lhs' = infer_ty [%here] (Expr.BasilExpr.rvar lhs) in
@@ -284,13 +284,13 @@ module Make (T : TypeExpr.TypeContext) = struct
         Instr_Load { lhs; rhs; addr = Scalar; attrib }
     | Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib } ->
         let addr = infer_ty [%here] addr in
-        let _ = unify (fix @@ ptr_typ) (getty addr) in
-        let mapt = fix @@ fun_type (getty addr) (fresh_tvar ()) in
+        let _ = unify ptr_typ (getty addr) in
+        let mapt = fun_type (getty addr) (fresh_tvar ()) in
         let _ = unify (lookup_var_typ univ ctx rhs) mapt in
         let _ =
           unify
             (infer_ty [%here] (Expr.BasilExpr.rvar lhs) |> getty)
-            (fix @@ bv_type size)
+            (bv_type size)
         in
         Instr_Load { lhs; rhs; addr = Addr { addr; size; endian }; attrib }
     | Instr_Store { lhs; rhs; value; addr = Scalar; attrib } ->
@@ -305,14 +305,14 @@ module Make (T : TypeExpr.TypeContext) = struct
     | Instr_Store
         { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib } ->
         let addr = infer_ty [%here] addr in
-        let _ = unify (fix @@ ptr_typ) (getty addr) in
-        let mapt = fix @@ fun_type (getty addr) (fresh_tvar ()) in
+        let _ = unify ptr_typ (getty addr) in
+        let mapt = fun_type (getty addr) (fresh_tvar ()) in
         let _ =
           unify mapt (infer ~univ [%here] (Expr.BasilExpr.rvar lhs) ctx)
         in
         let _ = unify (lookup_var_typ univ ctx rhs) mapt in
         let value = infer_ty [%here] value in
-        let _ = unify (getty value) (fix @@ bv_type size) in
+        let _ = unify (getty value) (bv_type size) in
         Instr_Store
           { lhs; rhs; value; addr = Addr { addr; size; endian }; attrib }
 

--- a/lib/lang/hm/solve_bv.ml
+++ b/lib/lang/hm/solve_bv.ml
@@ -4,15 +4,17 @@ open Common
 open Abstract_expr
 open Hm_types
 
-module Make (T : TypeExpr.TypeContext) = struct
-  include Unification.Make (T)
+module Make (Ctx : TypeExpr.TypeContext) = struct
+  open Unification.Make (Ctx)
+  open Hm_types.Make (Ctx)
 
   (** Naive solver *)
 
   (** Constraints between nat val types. *)
   type dependent_bv_constraints =
-    | Add of { a : Typ.t; b : Typ.t; equ : Typ.t }  (** a + b = equ*)
-    | AddConst of { a : Typ.t; b : int; equ : Typ.t }  (** a + b = equ*)
+    | Add of { a : Ctx.Typ.t; b : Ctx.Typ.t; equ : Ctx.Typ.t }
+        (** a + b = equ*)
+    | AddConst of { a : Ctx.Typ.t; b : int; equ : Ctx.Typ.t }  (** a + b = equ*)
 
   let show_dependent_bv_constraints = function
     | Add { a; b; equ } ->
@@ -23,7 +25,7 @@ module Make (T : TypeExpr.TypeContext) = struct
           (type_to_string equ)
 
   (** Deduce the width if two values of the constraint have inferred widths *)
-  let unify_bv_constraint constr : Typ.t option =
+  let unify_bv_constraint constr : Ctx.Typ.t option =
     match constr with
     | Add { a; b; equ } -> (
         match List.map is_nat_val_type [ find a; find b; find equ ] with

--- a/lib/lang/hm/solve_bv.ml
+++ b/lib/lang/hm/solve_bv.ml
@@ -33,26 +33,24 @@ module Make (Ctx : TypeExpr.TypeContext) = struct
         match List.map is_nat_val_type [ find a; find b; find equ ] with
         | [ Some a_n; Some b_n; Some e_n ] ->
             (* check constraint  *)
-            if a_n + b_n <> e_n then
-              type_error (fix @@ nat_val_type (a_n + b_n)) equ;
+            if a_n + b_n <> e_n then type_error (nat_val_type (a_n + b_n)) equ;
             Some equ
         | [ Some a_n; Some b_n; None ] ->
-            Some (unify ~pos:[%here] (fix @@ nat_val_type (a_n + b_n)) equ)
+            Some (unify ~pos:[%here] (nat_val_type (a_n + b_n)) equ)
         | [ Some a_n; None; Some e_n ] ->
-            Some (unify ~pos:[%here] (fix @@ nat_val_type (e_n - a_n)) b)
+            Some (unify ~pos:[%here] (nat_val_type (e_n - a_n)) b)
         | [ None; Some b_n; Some e_n ] ->
-            Some (unify ~pos:[%here] (fix @@ nat_val_type (e_n - b_n)) a)
+            Some (unify ~pos:[%here] (nat_val_type (e_n - b_n)) a)
         | _ -> None)
     | AddConst { a; b; equ } -> (
         match (is_nat_val_type (find a), is_nat_val_type (find equ)) with
         | Some a_n, Some e_n ->
             (* check constraint  *)
-            let e = fix @@ nat_val_type (a_n + b) in
+            let e = nat_val_type (a_n + b) in
             Some (unify ~pos:[%here] e equ)
         | Some a_n, None ->
-            Some (unify ~pos:[%here] (fix @@ nat_val_type (a_n + b)) equ)
-        | None, Some e_n ->
-            Some (unify ~pos:[%here] (fix @@ nat_val_type (e_n - b)) a)
+            Some (unify ~pos:[%here] (nat_val_type (a_n + b)) equ)
+        | None, Some e_n -> Some (unify ~pos:[%here] (nat_val_type (e_n - b)) a)
         | _ -> None)
 
   (** Naive solver; loop over constraints and unify until everything is solved.

--- a/lib/lang/hm/solve_bv.ml
+++ b/lib/lang/hm/solve_bv.ml
@@ -5,7 +5,7 @@ open Abstract_expr
 open Hm_types
 
 module Make (Ctx : TypeExpr.TypeContext) = struct
-  open Unification.Make (Ctx) (Hm_types.Make (Ctx))
+  open Unification.Make (Ctx)
   open Hm_types.Make (Ctx)
   open Ctx
   open Ctx.Typ

--- a/lib/lang/hm/solve_bv.ml
+++ b/lib/lang/hm/solve_bv.ml
@@ -5,7 +5,7 @@ open Abstract_expr
 open Hm_types
 
 module Make (Ctx : TypeExpr.TypeContext) = struct
-  open Unification.Make (Ctx)
+  open Unification.Make (Ctx) (Hm_types.Make (Ctx))
   open Hm_types.Make (Ctx)
   open Ctx
   open Ctx.Typ

--- a/lib/lang/hm/solve_bv.ml
+++ b/lib/lang/hm/solve_bv.ml
@@ -7,6 +7,8 @@ open Hm_types
 module Make (Ctx : TypeExpr.TypeContext) = struct
   open Unification.Make (Ctx)
   open Hm_types.Make (Ctx)
+  open Ctx
+  open Ctx.Typ
 
   (** Naive solver *)
 

--- a/lib/lang/hm/state.ml
+++ b/lib/lang/hm/state.ml
@@ -1,6 +1,0 @@
-let x = 2
-
-type 'a state = {
-  unionfind_state : 'a UnionFind.StoreVector.store;
-  hashcons_state : (module Fix.HashCons.SERVICE with type data = 'a);
-}

--- a/lib/lang/hm/state.ml
+++ b/lib/lang/hm/state.ml
@@ -1,0 +1,6 @@
+let x = 2
+
+type 'a state = {
+  unionfind_state : 'a UnionFind.StoreVector.store;
+  hashcons_state : (module Fix.HashCons.SERVICE with type data = 'a);
+}

--- a/lib/lang/hm/typeExpr.ml
+++ b/lib/lang/hm/typeExpr.ml
@@ -1,7 +1,6 @@
 (** Hash-consed (interned) type expresions with recusion schemes. *)
 
 open Common
-open UnionFind
 
 type tvar = ID.t [@@deriving eq, ord, show]
 (** Type variable identifier *)
@@ -57,7 +56,7 @@ module MakeFresh () = struct
     and nt = T of t expr
 
     module Hashed = struct
-      type t = nt elem
+      type t = nt UnionFind.elem
       (* we hash cons the data underlying the uf reference so we can construct the
        type and get the UF reference *)
 
@@ -69,12 +68,7 @@ module MakeFresh () = struct
         | T i, T j -> ATyp.equal_expr Fix.HashCons.equal i j
     end
 
-    open struct
-      module M = Fix.Memoize.ForHashedType (Hashed)
-      (** we need to make *)
-    end
-
-    module H = Fix.HashCons.Make (M)
+    module H = Fix.HashCons.ForHashedType (Hashed)
 
     let unfix : t -> t expr =
       Fix.HashCons.data %> UnionFind.find %> UnionFind.get %> function

--- a/lib/lang/hm/unification.ml
+++ b/lib/lang/hm/unification.ml
@@ -3,11 +3,10 @@
 open Common
 open Abstract_expr
 
-module Make
-    (T : TypeExpr.TypeContext)
-    (Hm_types' : module type of Hm_types.Make (T)) =
-struct
-  open Hm_types'
+module Make (T : TypeExpr.TypeContext) = struct
+  open Hm_types.Make (T)
+  (* XXX: todo *)
+
   open T
   open T.Typ
 

--- a/lib/lang/hm/unification.ml
+++ b/lib/lang/hm/unification.ml
@@ -7,6 +7,9 @@ module Make (T : TypeExpr.TypeContext) = struct
   open Hm_types.Make (T)
   (* XXX: todo *)
 
+  open T
+  open T.Typ
+
   let type_error a b =
     let a = find a in
     let b = find b in

--- a/lib/lang/hm/unification.ml
+++ b/lib/lang/hm/unification.ml
@@ -3,10 +3,11 @@
 open Common
 open Abstract_expr
 
-module Make (T : TypeExpr.TypeContext) = struct
-  open Hm_types.Make (T)
-  (* XXX: todo *)
-
+module Make
+    (T : TypeExpr.TypeContext)
+    (Hm_types' : module type of Hm_types.Make (T)) =
+struct
+  open Hm_types'
   open T
   open T.Typ
 

--- a/lib/lang/hm/unification.ml
+++ b/lib/lang/hm/unification.ml
@@ -4,28 +4,26 @@ open Common
 open Abstract_expr
 
 module Make (T : TypeExpr.TypeContext) = struct
-  open TypeExpr
-  include T
-  include Typ
-  open Hm_types
-  include Hm_types.Make (T)
+  open Hm_types.Make (T)
+  (* XXX: todo *)
 
   let type_error a b =
     let a = find a in
     let b = find b in
     raise
-      (TypeErr ("type_error: " ^ type_to_string a ^ " <> " ^ type_to_string b))
+      (Hm_types.TypeErr
+         ("type_error: " ^ type_to_string a ^ " <> " ^ type_to_string b))
 
   let recursion_error a b =
     let b = find b in
     raise
-      (TypeErr
+      (Hm_types.TypeErr
          ("recursive: tvar " ^ ID.to_string a ^ " occurs in " ^ type_to_string b))
 
   (** Check for type recursion: recursion is failure. *)
   let occurs_in a b =
     let check = function
-      | Var t -> equal_tvar t a
+      | Var t -> TypeExpr.equal_tvar t a
       | TypeConstr (ls, _) -> List.exists Fun.id ls
     in
     Rec.cata check b
@@ -78,18 +76,18 @@ module Make (T : TypeExpr.TypeContext) = struct
   let lookup_var_typ univ ?(no_constraint = false) c v =
     let vt = inst_annot_v v in
     let a =
-      let v = V.of_var univ v in
-      TCtx.find_opt v c |> function
+      let v = TypeExpr.V.of_var univ v in
+      TypeExpr.TCtx.find_opt v c |> function
       | Some v -> v
-      | None -> failwith ("var not found: " ^ V.to_string v)
+      | None -> failwith ("var not found: " ^ TypeExpr.V.to_string v)
     in
     let tt = match a with Forall (_, ty) -> union ty vt in
     tt
 
   (** declare type with name in type scheme *)
   let decl_type ctx name vt =
-    let tvar = V.create types_universe name in
-    TCtx.update tvar
+    let tvar = TypeExpr.V.create types_universe name in
+    TypeExpr.TCtx.update tvar
       (function
         | Some (Forall ([], t)) -> Some (Forall ([], unify vt t))
         | None -> Some (Forall ([], vt))
@@ -98,9 +96,9 @@ module Make (T : TypeExpr.TypeContext) = struct
 
   (** declare var with type in type scheme *)
   let decl_var_typ univ ?(no_constraint = false) c v =
-    let vvar = V.of_var univ v in
+    let vvar = TypeExpr.V.of_var univ v in
     let vt = inst_annot_v v in
-    TCtx.update vvar
+    TypeExpr.TCtx.update vvar
       (function
         | Some (Forall ([], t)) -> Some (Forall ([], unify vt t))
         | None -> Some (Forall ([], vt))


### PR DESCRIPTION
This removes the uses of include which accumulated all earlier HM modules into later ones. This makes it so each function has one canonical definition site, and avoids inflating the docs.

For simplicity, this is just done by changing includes to opens, so it is still a little hard to see where a function comes from. But I think it is still an improvement.

Independently, this also embeds calls to `fix` into the type smart constructors. This avoids needing to call fix separately after every call to the constructors, and is planned to help with moving the HC state to value level. This might have a side-effect of eagerly adding all the primitive types to every HC context, but I think this is not a big problem.

These two changes could be separated if you want.

follow up to https://github.com/agle/bincaml/pull/216